### PR TITLE
Fix road objects changes

### DIFF
--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -219,10 +219,15 @@ static void loadPhysicsObjects(PhysicsLoader &loader)
         .muD = 0.5f,
     });
 
-    // setupHull(SimObject::Cylinder, 0.075f, {
-    //     .muS = 0.5f,
-    //     .muD = 0.75f,
-    // });
+    setupHull(SimObject::StopSign, 1.f, {
+    .muS = 0.5f,
+    .muD = 0.5f,
+        });
+
+    setupHull(SimObject::SpeedBump, 1.f, {
+        .muS = 0.5f,
+        .muD = 0.5f,
+    });
 
     SourceCollisionPrimitive plane_prim {
         .type = CollisionPrimitive::Type::Plane,


### PR DESCRIPTION
This is a very short PR that introduces a fix that I did in [GPU PR](https://github.com/Emerge-Lab/gpudrive/pull/13) regarding road objects. 

The only change is initialization of physics objects for 2 new object types.