### PR TITLE
Add Shape tensor

### DIFF
--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -72,6 +72,7 @@ int main(int argc, char *argv[])
     auto self_printer = mgr.selfObservationTensor().makePrinter();
     auto partner_obs_printer = mgr.partnerObservationsTensor().makePrinter();
     auto map_obs_printer = mgr.mapObservationTensor().makePrinter();
+    auto shapePrinter = mgr.shapeTensor().makePrinter();
 
     auto printObs = [&]() {
         printf("Self\n");
@@ -89,6 +90,9 @@ int main(int argc, char *argv[])
         printf("Map Obs\n");
         // map_obs_printer.print();
         printf("\n");
+
+        printf("Shape\n");
+        shapePrinter.print();
     };
     // printObs();
     for (CountT i = 0; i < (CountT)num_steps; i++) {

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -289,6 +289,10 @@ void createPersistentEntities(Engine &ctx, const AgentInit *agentInits,
         createRoadEntities(ctx, roadInit, roadIdx);
     }
     ctx.data().numRoads = roadIdx;
+
+    auto &shape = ctx.singleton<Shape>();
+    shape.agentEntityCount = ctx.data().numAgents;
+    shape.roadEntityCount = ctx.data().numRoads;
 }
 
 static void generateLevel(Engine &) {}

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -504,6 +504,11 @@ Tensor Manager::stepsRemainingTensor() const
                                });
 }
 
+Tensor Manager::shapeTensor() const {
+    return impl_->exportTensor(ExportID::Shape, Tensor::ElementType::Int32,
+                               {impl_->cfg.numWorlds, 2});
+}
+
 void Manager::triggerReset(int32_t world_idx)
 {
     WorldReset reset {

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -49,6 +49,7 @@ public:
     MGR_EXPORT madrona::py::Tensor lidarTensor() const;
     MGR_EXPORT madrona::py::Tensor stepsRemainingTensor() const;
     MGR_EXPORT madrona::py::Tensor bicycleModelTensor() const;
+    MGR_EXPORT madrona::py::Tensor shapeTensor() const;
     // These functions are used by the viewer to control the simulation
     // with keyboard inputs in place of DNN policy actions
     MGR_EXPORT void triggerReset(int32_t world_idx);

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -38,12 +38,14 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &)
 
     registry.registerSingleton<WorldReset>();
     registry.registerSingleton<LevelState>();
+    registry.registerSingleton<Shape>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
 
     registry.exportSingleton<WorldReset>(
         (uint32_t)ExportID::Reset);
+    registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
     registry.exportColumn<Agent, Action>(
         (uint32_t)ExportID::Action);
     registry.exportColumn<Agent, SelfObservation>(

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -26,6 +26,7 @@ enum class ExportID : uint32_t {
     StepsRemaining,
     BicycleModel,
     MapObservation,
+    Shape,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -141,6 +141,11 @@ struct Trajectory {
     float initialHeading;
 };
 
+struct Shape {
+    int32_t agentEntityCount;
+    int32_t roadEntityCount;
+};
+
 /* ECS Archetypes for the game */
 
 // There are 2 Agents in the environment trying to get to the destination
@@ -171,7 +176,6 @@ struct Agent : public madrona::Archetype<
     VehicleSize,
     Goal,
     Trajectory,
-
     // Input
     Action,
 


### PR DESCRIPTION
Tensors will be padded in https://github.com/Emerge-Lab/gpudrive/pull/19 to support ragged dimensions. To that end, this PR adds a `Shape` tensor that specifies the _real_ number of entities present in each world in order to avoid iterating over padding values. This tensor will be used both internally by `gpudrive` (for instance, in `headless.cpp` to iterate over the true number of agents) and externally by the learning component.