### PR TITLE
Move deallocation out of device context

### DIFF
--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -307,6 +307,11 @@ Manager::Impl * Manager::Impl::init(
         Action *agent_actions_buffer = 
             (Action *)gpu_exec.getExported((uint32_t)ExportID::Action);
 
+        for (int64_t i = 0; i < (int64_t)mgr_cfg.numWorlds; i++) {
+          auto &init = world_inits[i];
+          madrona::cu::deallocGPU(init.agentInits);
+          madrona::cu::deallocGPU(init.roadInits);
+        }
 
         return new CUDAImpl {
             mgr_cfg,
@@ -316,6 +321,7 @@ Manager::Impl * Manager::Impl::init(
             agent_actions_buffer,
             std::move(gpu_exec),
         };
+
 #else
         FATAL("Madrona was not compiled with CUDA support");
 #endif
@@ -362,6 +368,13 @@ Manager::Impl * Manager::Impl::init(
             agent_actions_buffer,
             std::move(cpu_exec),
         };
+
+        for (int64_t i = 0; i < (int64_t)mgr_cfg.numWorlds; i++) {
+          auto &init = world_inits[i];
+
+          free(init.agentInits);
+          free(init.roadInits);
+        }
 
         return cpu_impl;
     } break;

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -544,23 +544,6 @@ Sim::Sim(Engine &ctx,
     createPersistentEntities(ctx, init.agentInits, init.agentInitsCount,
                              init.roadInits, init.roadInitsCount);
 
-    // TODO: Wrap below pointers with std::unique_ptr with a custom deleter.
-    // Even with unique_ptr, these pointers would need to be explicitly free'd
-    // with a call to, say, reset(), because their lifetime does not match that
-    // of WorldInit.
-    if (init.mode == madrona::ExecMode::CUDA) {
-#ifdef MADRONA_CUDA_SUPPORT
-        madrona::cu::deallocGPU(init.agentInits);
-        madrona::cu::deallocGPU(init.roadInits);
-#else
-        FATAL("Madrona was not compiled with CUDA support");
-#endif
-    } else {
-        assert(init.mode == madrona::ExecMode::CPU);
-        free(init.agentInits);
-        free(init.roadInits);
-    }
-
     // Generate initial world state
     initWorld(ctx);
 }


### PR DESCRIPTION
We have good reason to believe that `madrona::cu::deallocGPU()` can't be invoked in a device context. This issue is hidden by a (as of yet unexplained) incorrect value for `init.mode` in Sim's constructor.
