### PR TITLE
Calculate AFPS metric

### DIFF
--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -151,4 +151,13 @@ int main(int argc, char *argv[])
 
     float fps = (double)num_steps * (double)num_worlds / elapsed.count();
     printf("FPS %f\n", fps);
+
+    uint64_t totalAgentCount{0};
+    for (CountT j = 0; j < (CountT)num_worlds; j++) {
+      auto agentCount = worldToShape.at(j).agentEntityCount;
+      totalAgentCount += agentCount;
+    }
+
+    float fpsNormalized = fps * totalAgentCount;
+    printf("Agent-Normalized FPS %f\n", fpsNormalized);
 }


### PR DESCRIPTION
This calculates Agent Frames Per Second (AFPS) by multiplying FPS by the sum of _real_ agents (ie. non-padding) across all worlds.
