### PR TITLE
Skip padding entites in LiDAR

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -268,6 +268,7 @@ static inline float encodeType(EntityType type)
 // and each thread in the warp traces one lidar ray for the agent.
 inline void lidarSystem(Engine &ctx, Entity e, Lidar &lidar,
                         EntityType &entityType) {
+    assert(entityType != EntityType::None);
     if (entityType == EntityType::Padding) {
         return;
     }


### PR DESCRIPTION
This skips executing the LiDAR system for padding entities. Because the LiDAR system allocates 4096 bytes for each entity in each environment, fixing this has increased the maximum batch size to at least 350 environments.