### PR TITLE
Change collision state export

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -68,8 +68,7 @@ namespace gpudrive
             .def("partner_observations_tensor", &Manager::partnerObservationsTensor)
             .def("lidar_tensor", &Manager::lidarTensor)
             .def("steps_remaining_tensor", &Manager::stepsRemainingTensor)
-            .def("shape_tensor", &Manager::shapeTensor)
-            .def("collision_tensor", &Manager::collisionTensor);
+            .def("shape_tensor", &Manager::shapeTensor);
     }
 
 }

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
         .gpuID = 0,
         .numWorlds = (uint32_t)num_worlds,
         .autoReset = false,
-        .jsonPath = "tests/testJsons",
+        .jsonPath = "/home/samk/gpudrive/maps.small",
         .params = {
             .polylineReductionThreshold = 1.0,
             .observationRadius = 100.0,
@@ -89,7 +89,6 @@ int main(int argc, char *argv[])
     auto rewardPrinter = mgr.rewardTensor().makePrinter();
     auto donePrinter = mgr.doneTensor().makePrinter();
     auto controlledStatePrinter = mgr.controlledStateTensor().makePrinter();
-    auto collisionPrinter = mgr.collisionTensor().makePrinter();
     auto agent_map_obs_printer = mgr.agentMapObservationsTensor().makePrinter();
 
     auto printObs = [&]() {
@@ -121,9 +120,6 @@ int main(int argc, char *argv[])
         printf("Controlled State\n");
         controlledStatePrinter.print();
         
-        printf("Collision\n");
-        collisionPrinter.print();
-
         printf("Agent Map Obs\n");
         agent_map_obs_printer.print();
     };

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -493,7 +493,7 @@ Tensor Manager::selfObservationTensor() const
                                {
                                    impl_->cfg.numWorlds,
                                    impl_->agentRoadCounts.first,
-                                   8
+                                   6
                                });
 }
 
@@ -600,12 +600,6 @@ void Manager::setAction(int32_t world_idx, int32_t agent_idx,
     } else {
         *action_ptr = action;
     }
-}
-
-Tensor Manager::collisionTensor() const {
-    return impl_->exportTensor(
-        ExportID::Collision, Tensor::ElementType::Int32,
-        {impl_->cfg.numWorlds, consts::kMaxAgentCount, 1});
 }
 
 std::vector<Shape>

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -58,7 +58,6 @@ public:
     MGR_EXPORT madrona::py::Tensor bicycleModelTensor() const;
     MGR_EXPORT madrona::py::Tensor shapeTensor() const;
     MGR_EXPORT madrona::py::Tensor controlledStateTensor() const;
-    MGR_EXPORT madrona::py::Tensor collisionTensor() const;
     // These functions are used by the viewer to control the simulation
     // with keyboard inputs in place of DNN policy actions
     MGR_EXPORT void triggerReset(int32_t world_idx);

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -39,7 +39,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &)
     registry.registerComponent<Goal>();
     registry.registerComponent<Trajectory>();
     registry.registerComponent<ControlledState>();
-    registry.registerComponent<CollisionEvent>();
 
     registry.registerSingleton<WorldReset>();
     registry.registerSingleton<Shape>();
@@ -73,8 +72,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &)
         (uint32_t) ExportID::BicycleModel);
     registry.exportColumn<Agent, ControlledState>(
         (uint32_t) ExportID::ControlledState);
-    registry.exportColumn<Agent, CollisionEvent>(
-        static_cast<uint32_t>(ExportID::Collision));
 }
 
 static inline void cleanupWorld(Engine &ctx) {}
@@ -144,7 +141,8 @@ inline void collectObservationsSystem(Engine &ctx,
                                       SelfObservation &self_obs,
                                       PartnerObservations &partner_obs,
                                       AgentMapObservations &map_obs,
-				      const EntityType& entityType) {
+				      const EntityType& entityType,
+				      const CollisionEvent& collisionEvent) {
      if (entityType == EntityType::Padding) {
        return;
      }
@@ -152,6 +150,10 @@ inline void collectObservationsSystem(Engine &ctx,
     self_obs.speed = model.speed;
     self_obs.vehicle_size = size; 
     self_obs.goal.position = goal.position - model.position;
+
+    auto hasCollided = collisionEvent.hasCollided.load_relaxed();
+    self_obs.collisionState = hasCollided ? 1.f : 0.f;
+
 
     CountT arrIndex = 0; CountT agentIdx = 0;
     while(agentIdx < ctx.data().numAgents - 1)
@@ -547,7 +549,7 @@ void Sim::setupTasks(TaskGraphBuilder &builder, const Config &cfg)
             EntityType,
             StepsRemaining,
             Trajectory,
-             ExternalForce,
+            ExternalForce,
             ExternalTorque,
             CollisionEvent
         >>({});
@@ -630,8 +632,9 @@ void Sim::setupTasks(TaskGraphBuilder &builder, const Config &cfg)
             OtherAgents,
             SelfObservation,
 	    PartnerObservations,
-        AgentMapObservations,
-            EntityType
+            AgentMapObservations,
+            EntityType,
+            madrona::phys::CollisionEvent
         >>({post_reset_broadphase});
 
 

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -28,7 +28,6 @@ enum class ExportID : uint32_t {
     MapObservation,
     Shape,
     ControlledState,
-    Collision,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -69,6 +69,7 @@ struct SelfObservation {
     float speed;
     VehicleSize vehicle_size;
     Goal goal;
+    float collisionState;
 };
 
 struct MapObservation {

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -199,7 +199,6 @@ int main(int argc, char *argv[])
     auto lidar_printer = mgr.lidarTensor().makePrinter();
     auto steps_remaining_printer = mgr.stepsRemainingTensor().makePrinter();
     auto reward_printer = mgr.rewardTensor().makePrinter();
-    auto collisionPrinter = mgr.collisionTensor().makePrinter();
 
     auto printObs = [&]() {
         printf("Self\n");
@@ -216,9 +215,6 @@ int main(int argc, char *argv[])
 
         printf("Reward\n");
         reward_printer.print();
-
-        printf("Collision\n");
-        collisionPrinter.print();
 
         printf("\n");
     };


### PR DESCRIPTION
`CollisionEvent` is defined as 

```
 struct CollisionEvent {
    AtomicI32 hasCollided{false};
 };
```

Previously, this was being exported directly as a tensor, which I think led to the incorrect tensor shape seen by Eugene. To remedy this, this PR extends `SelfObservation` with a `float collisionState` that specifies whether an agent has collided.