### PR TITLE
Compute and export absolute agent observations

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -71,7 +71,9 @@ namespace gpudrive
             .def("steps_remaining_tensor", &Manager::stepsRemainingTensor)
             .def("shape_tensor", &Manager::shapeTensor)
             .def("controlled_state_tensor", &Manager::controlledStateTensor)
-            .def("agent_roadmap_tensor", &Manager::agentMapObservationsTensor);
+            .def("agent_roadmap_tensor", &Manager::agentMapObservationsTensor)
+            .def("absolute_self_observation_tensor",
+                 &Manager::absoluteSelfObservationTensor);
     }
 
 }

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -703,6 +703,12 @@ Tensor Manager::controlledStateTensor() const {
                                {impl_->cfg.numWorlds, consts::kMaxAgentCount, 1});
 }
 
+Tensor Manager::absoluteSelfObservationTensor() const {
+    return impl_->exportTensor(
+        ExportID::AbsoluteSelfObservation, TensorElementType::Float32,
+        {impl_->cfg.numWorlds, consts::kMaxAgentCount, 3 + 4 + 1 + 2});
+}
+
 void Manager::triggerReset(int32_t world_idx)
 {
     WorldReset reset {

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -62,6 +62,7 @@ public:
     MGR_EXPORT madrona::py::Tensor bicycleModelTensor() const;
     MGR_EXPORT madrona::py::Tensor shapeTensor() const;
     MGR_EXPORT madrona::py::Tensor controlledStateTensor() const;
+    MGR_EXPORT madrona::py::Tensor absoluteSelfObservationTensor() const;
     // These functions are used by the viewer to control the simulation
     // with keyboard inputs in place of DNN policy actions
     MGR_EXPORT void triggerReset(int32_t world_idx);

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -28,6 +28,7 @@ enum class ExportID : uint32_t {
     MapObservation,
     Shape,
     ControlledState,
+    AbsoluteSelfObservation,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -98,8 +98,6 @@ struct AgentMapObservations {
     MapObservation obs[consts::kMaxRoadEntityCount];
 };
 
-
-
 struct LidarSample {
     float depth;
     float encodedType;
@@ -165,6 +163,17 @@ struct CollisionDetectionEvent {
     madrona::AtomicI32 hasCollided{false};
 };
 
+struct AbsoluteRotation {
+    Rotation rotationAsQuat;
+    float rotationFromAxis;
+};
+
+struct AbsoluteSelfObservation {
+    Position position;
+    AbsoluteRotation rotation;
+    Goal goal;
+};
+
 /* ECS Archetypes for the game */
 
 // There are 2 Agents in the environment trying to get to the destination
@@ -197,10 +206,12 @@ struct Agent : public madrona::Archetype<
 
     // Observations
     SelfObservation,
+    AbsoluteSelfObservation,
     PartnerObservations,
     AgentMapObservations,
     Lidar,
     StepsRemaining,
+    
 
     // Reward, episode termination
     Reward,


### PR DESCRIPTION
This exports a new tensor `absolute_self_observation_tensor` which contains the position, rotation, and goal for every agent across all worlds. This will be used for visualizing an environment in PyGame.

This new tensor has shape `W x A x AbsoluteSelfObservation`.

