### PR TITLE
Export validity of expert trajectory

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -73,7 +73,8 @@ namespace gpudrive
             .def("controlled_state_tensor", &Manager::controlledStateTensor)
             .def("agent_roadmap_tensor", &Manager::agentMapObservationsTensor)
             .def("absolute_self_observation_tensor",
-                 &Manager::absoluteSelfObservationTensor);
+                 &Manager::absoluteSelfObservationTensor)
+            .def("valid_state_tensor", &Manager::validStateTensor);
     }
 
 }

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -709,6 +709,12 @@ Tensor Manager::absoluteSelfObservationTensor() const {
         {impl_->cfg.numWorlds, consts::kMaxAgentCount, 3 + 4 + 1 + 2});
 }
 
+Tensor Manager::validStateTensor() const {
+    return impl_->exportTensor(
+        ExportID::ValidState, TensorElementType::Int32,
+        {impl_->cfg.numWorlds, consts::kMaxAgentCount, 1});
+}
+
 void Manager::triggerReset(int32_t world_idx)
 {
     WorldReset reset {

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -63,6 +63,7 @@ public:
     MGR_EXPORT madrona::py::Tensor shapeTensor() const;
     MGR_EXPORT madrona::py::Tensor controlledStateTensor() const;
     MGR_EXPORT madrona::py::Tensor absoluteSelfObservationTensor() const;
+    MGR_EXPORT madrona::py::Tensor validStateTensor() const;
     // These functions are used by the viewer to control the simulation
     // with keyboard inputs in place of DNN policy actions
     MGR_EXPORT void triggerReset(int32_t world_idx);

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -16,6 +16,10 @@ namespace RenderingSystem = madrona::render::RenderingSystem;
 
 namespace gpudrive {
 
+CountT getCurrentStep(const StepsRemaining &stepsRemaining) {
+  return consts::episodeLen - stepsRemaining.t;
+}
+
 // Register all the ECS components and archetypes that will be
 // used in the simulation
 void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
@@ -46,6 +50,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerComponent<AbsoluteSelfObservation>();
     registry.registerSingleton<WorldReset>();
     registry.registerSingleton<Shape>();
+    registry.registerSingleton<ValidState>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
@@ -53,6 +58,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<WorldReset>(
         (uint32_t)ExportID::Reset);
     registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
+    registry.exportSingleton<ValidState>((uint32_t)ExportID::ValidState);
     registry.exportColumn<Agent, Action>(
         (uint32_t)ExportID::Action);
     registry.exportColumn<Agent, SelfObservation>(
@@ -284,7 +290,7 @@ inline void movementSystem(Engine &e,
     else
     {
         // Follow expert trajectory
-        CountT curStepIdx = consts::episodeLen - stepsRemaining.t;
+        CountT curStepIdx = getCurrentStep(stepsRemaining);
         model.position= trajectory.positions[curStepIdx];
         model.heading = trajectory.headings[curStepIdx];
         model.speed = trajectory.velocities[curStepIdx].length();
@@ -546,6 +552,29 @@ inline void collectAbsoluteObservationsSystem(Engine &ctx,
     out.goal = goal;
 }
 
+inline void validStateSystem(Engine &ctx, ValidState &validOut) {
+    // This assumes StepsRemaining is constant across all agents
+    Entity anyAgent = ctx.data().agents[0];
+    const auto stepsRemaining = ctx.get<StepsRemaining>(anyAgent);
+    const CountT currentStep = getCurrentStep(stepsRemaining);
+
+    for (CountT agentIdx = 0; agentIdx < ctx.data().numAgents; ++agentIdx) {
+        auto agentHandle = ctx.data().agents[agentIdx];
+        const auto &trajectory = ctx.get<Trajectory>(agentHandle);
+
+        assert(currentStep < consts::kTrajectoryLength);
+        int32_t isValid = trajectory.valids[currentStep];
+
+        validOut.valid[agentIdx] = static_cast<Validity>(isValid);
+    }
+
+    for (CountT agentIdx = ctx.data().numAgents;
+         agentIdx < consts::kMaxAgentCount; ++agentIdx) {
+        auto agentHandle = ctx.data().agents[agentIdx];
+        validOut.valid[agentIdx] = Validity::Invalid;
+    }
+}
+
 // Build the task graph
 void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
 {
@@ -567,13 +596,17 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
             CollisionDetectionEvent
         >>({});
 
+    auto updateValidStateSystem =
+        builder
+            .addToGraph<ParallelForNode<Engine, validStateSystem, ValidState>>(
+                {moveSystem});
+
     // setupBroadphaseTasks consists of the following sub-tasks:
     // 1. updateLeafPositionsEntry
     // 2. broadphase::updateBVHEntry
     // 3. broadphase::refitEntry
-    auto broadphase_setup_sys =
-        phys::PhysicsSystem::setupBroadphaseTasks(builder,
-                                                           {moveSystem});
+    auto broadphase_setup_sys = phys::PhysicsSystem::setupBroadphaseTasks(
+        builder, {updateValidStateSystem});
 
     auto findOverlappingEntities =
         phys::PhysicsSystem::setupBroadphaseOverlapTasks(

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -29,6 +29,7 @@ enum class ExportID : uint32_t {
     Shape,
     ControlledState,
     AbsoluteSelfObservation,
+    ValidState,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -174,6 +174,15 @@ struct AbsoluteSelfObservation {
     Goal goal;
 };
 
+enum class Validity : int32_t {
+    Invalid = 0,
+    Valid = 1
+};
+
+struct ValidState {
+    Validity valid[consts::kMaxAgentCount];
+};
+
 /* ECS Archetypes for the game */
 
 // There are 2 Agents in the environment trying to get to the destination
@@ -201,6 +210,7 @@ struct Agent : public madrona::Archetype<
     Goal,
     Trajectory,
     ControlledState,
+
     // Input
     Action,
 
@@ -212,7 +222,6 @@ struct Agent : public madrona::Archetype<
     Lidar,
     StepsRemaining,
     
-
     // Reward, episode termination
     Reward,
     Done,


### PR DESCRIPTION
This adds the tensor `valid_state_tensor` with dimensions `W x N x 1` which for each agent in each world, specifies whether the expert trajectory for that agent is in a valid state.