### PR TITLE
Use pygame to rotate agents

### DIFF
--- a/data/green_agent.svg
+++ b/data/green_agent.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docname="creep_green.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:export-filename="D:\eli\graphics\inkscape\creep_pink_45.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective10" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.6547131"
+     inkscape:cy="9.4192553"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1000"
+     inkscape:window-height="959"
+     inkscape:window-x="220"
+     inkscape:window-y="-2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2383"
+       visible="true"
+       enabled="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#6cd69b;fill-opacity:1;stroke:#3ebf41;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2385"
+       sodipodi:cx="7"
+       sodipodi:cy="8"
+       sodipodi:rx="7"
+       sodipodi:ry="7"
+       d="M 14,8 A 7,7 0 1 1 0,8 A 7,7 0 1 1 14,8 z"
+       transform="matrix(0.942942,-0.9429419,0.942942,0.9429419,-4.1441294,9.0570585)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#198248;fill-opacity:1;stroke:none;stroke-width:0;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3179"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="matrix(2,-2.1113084,2,2.1113084,-1,34.502663)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#198248;fill-opacity:1;stroke:none;stroke-width:0;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3178"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="matrix(2,-2.1113084,2,2.1113084,-1,40.502663)" />
+  </g>
+</svg>

--- a/data/pink_agent.svg
+++ b/data/pink_agent.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="15"
+   height="15"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docname="creep_pink.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:export-filename="D:\eli\graphics\inkscape\creep_circle.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective10" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="6.473652"
+     inkscape:cy="4.340226"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1000"
+     inkscape:window-height="959"
+     inkscape:window-x="220"
+     inkscape:window-y="-2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2383"
+       visible="true"
+       enabled="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#5f7d94;fill-opacity:1;stroke:#c351b8;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2385"
+       sodipodi:cx="7"
+       sodipodi:cy="8"
+       sodipodi:rx="7"
+       sodipodi:ry="7"
+       d="M 14,8 A 7,7 0 1 1 0,8 A 7,7 0 1 1 14,8 z"
+       transform="translate(0.5,-0.5)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#5e1228;fill-opacity:1;stroke:#5e1228;stroke-width:0.90899998000000004;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3179"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="translate(0,7.5)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#5e1228;fill-opacity:1;stroke:#5e1228;stroke-width:0.90899998000000004;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;color:#000000;fill-rule:nonzero;stroke-linecap:butt;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-dashoffset:0;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path3181"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="translate(0,12.5)" />
+    <path
+       style="opacity:1;fill:#ff9bff;fill-opacity:1;stroke:#003366;stroke-width:0.02840625000000000;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.904902,13.971861 C 5.2537467,13.771676 3.953767,13.150586 2.8631754,12.040847 C 0.76271794,9.9035121 0.40700106,6.6167702 1.9984367,4.0508477 C 2.8572336,2.6661824 4.2839082,1.6237009 5.8850661,1.2108596 C 6.9080264,0.94710087 8.0892782,0.94710056 9.1122379,1.2108596 C 10.25743,1.5061356 11.235885,2.0663606 12.07983,2.9099881 C 15.210699,6.0396784 14.369105,11.315182 10.423218,13.294411 C 9.8102967,13.601849 9.2034711,13.800576 8.529902,13.914449 C 8.244732,13.962659 7.148472,14.00139 6.904902,13.97186 L 6.904902,13.971861 z M 10.913376,10.867271 C 11.636564,10.501136 11.641143,9.4997006 10.92125,9.1452984 C 10.749045,9.0605221 10.680919,9.0443327 10.496374,9.0443327 C 10.308132,9.0443331 10.24672,9.0595687 10.068484,9.1504909 C 9.7161936,9.3301999 9.5448701,9.6175193 9.5486523,10.022274 C 9.5524451,10.428263 9.7867176,10.750205 10.201777,10.919814 C 10.357432,10.983421 10.73971,10.955194 10.913375,10.867271 L 10.913376,10.867271 z M 10.913376,5.8672706 C 11.636564,5.5011362 11.641143,4.4997006 10.92125,4.1452984 C 10.749045,4.0605221 10.680919,4.0443327 10.496374,4.0443327 C 10.308132,4.0443331 10.24672,4.0595687 10.068484,4.1504909 C 9.7161936,4.3302009 9.5448701,4.6175193 9.5486523,5.022274 C 9.5524451,5.4282634 9.7867176,5.7502046 10.201777,5.9198137 C 10.357432,5.9834199 10.73971,5.9551937 10.913375,5.8672706 L 10.913376,5.8672706 z"
+       id="path2386" />
+  </g>
+</svg>

--- a/data/yellow_agent.svg
+++ b/data/yellow_agent.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="15"
+   height="15"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docname="creep_yellow.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:export-filename="D:\eli\graphics\inkscape\creep_yellow_0.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective10" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.3008929"
+     inkscape:cy="4.340226"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1000"
+     inkscape:window-height="959"
+     inkscape:window-x="325"
+     inkscape:window-y="11">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2383"
+       visible="true"
+       enabled="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#f2ff2c;fill-opacity:1;stroke:#d5d565;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2385"
+       sodipodi:cx="7"
+       sodipodi:cy="8"
+       sodipodi:rx="7"
+       sodipodi:ry="7"
+       d="M 14,8 A 7,7 0 1 1 0,8 A 7,7 0 1 1 14,8 z"
+       transform="translate(0.5,-0.5)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#5b6029;fill-opacity:1;stroke:#5b6029;stroke-width:0.90900000000000003;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3179"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="translate(0,7.5)" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#5b6029;fill-opacity:1;stroke:#5b6029;stroke-width:0.90900000000000003;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;color:#000000;fill-rule:nonzero;stroke-linecap:butt;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-dashoffset:0;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path3181"
+       sodipodi:cx="10.5"
+       sodipodi:cy="-2.5"
+       sodipodi:rx="0.5"
+       sodipodi:ry="0.5"
+       d="M 11,-2.5 A 0.5,0.5 0 1 1 10,-2.5 A 0.5,0.5 0 1 1 11,-2.5 z"
+       transform="translate(0,12.5)" />
+    <path
+       style="opacity:1;fill:#f2e900;fill-opacity:1;stroke:#e1eb34;stroke-width:0.02840625000000000;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.904902,13.971861 C 5.2537467,13.771676 3.953767,13.150586 2.8631754,12.040847 C 0.76271794,9.9035121 0.40700106,6.6167702 1.9984367,4.0508477 C 2.8572336,2.6661824 4.2839082,1.6237009 5.8850661,1.2108596 C 6.9080264,0.94710087 8.0892782,0.94710056 9.1122379,1.2108596 C 10.25743,1.5061356 11.235885,2.0663606 12.07983,2.9099881 C 15.210699,6.0396784 14.369105,11.315182 10.423218,13.294411 C 9.8102967,13.601849 9.2034711,13.800576 8.529902,13.914449 C 8.244732,13.962659 7.148472,14.00139 6.904902,13.97186 L 6.904902,13.971861 z M 10.913376,10.867271 C 11.636564,10.501136 11.641143,9.4997006 10.92125,9.1452984 C 10.749045,9.0605221 10.680919,9.0443327 10.496374,9.0443327 C 10.308132,9.0443331 10.24672,9.0595687 10.068484,9.1504909 C 9.7161936,9.3301999 9.5448701,9.6175193 9.5486523,10.022274 C 9.5524451,10.428263 9.7867176,10.750205 10.201777,10.919814 C 10.357432,10.983421 10.73971,10.955194 10.913375,10.867271 L 10.913376,10.867271 z M 10.913376,5.8672706 C 11.636564,5.5011362 11.641143,4.4997006 10.92125,4.1452984 C 10.749045,4.0605221 10.680919,4.0443327 10.496374,4.0443327 C 10.308132,4.0443331 10.24672,4.0595687 10.068484,4.1504909 C 9.7161936,4.3302009 9.5448701,4.6175193 9.5486523,5.022274 C 9.5524451,5.4282634 9.7867176,5.7502046 10.201777,5.9198137 C 10.357432,5.9834199 10.73971,5.9551937 10.913375,5.8672706 L 10.913376,5.8672706 z"
+       id="path2386" />
+  </g>
+</svg>

--- a/pygpudrive/env/base_environment.py
+++ b/pygpudrive/env/base_environment.py
@@ -4,17 +4,17 @@ from gymnasium.spaces import Box, Discrete
 import numpy as np
 import torch
 from itertools import product
+
 # import wandb
 import glob
 import gymnasium as gym
 from gymnasium.error import DependencyNotInstalled
-import pygame
 import random
 import os
 import math
 
-# Import the EnvConfig dataclass
 from pygpudrive.env.config import EnvConfig
+from pygpudrive.env.viz import Visualizer
 
 # Import the simulator
 import gpudrive
@@ -22,56 +22,6 @@ import logging
 
 logging.getLogger(__name__)
 
-WINDOW_W = 500
-WINDOW_H = 500
-WINDOW_SIZE = (WINDOW_W, WINDOW_H)
-VEH_WIDTH = 5
-VEH_HEIGHT = 10
-GOAL_RADIUS = 2
-COLOR_LIST = [
-    (255, 0, 0),  # Red
-    (0, 255, 0),  # Green
-    (0, 0, 255),  # Blue
-    (255, 255, 0),  # Yellow
-    (255, 165, 0),  # Orange
-]
-
-# https://stackoverflow.com/a/73855696
-def compute_agent_corners(center, width, height, rotation):
-    """Draw a rectangle, centered at x, y.
-
-    Arguments:
-      x (int/float):
-        The x coordinate of the center of the shape.
-      y (int/float):
-        The y coordinate of the center of the shape.
-      width (int/float):
-        The width of the rectangle.
-      height (int/float):
-        The height of the rectangle.
-    """
-    x, y = center
-    
-    points = []
-
-    # The distance from the center of the rectangle to
-    # one of the corners is the same for each corner.
-    radius = math.sqrt((height / 2)**2 + (width / 2)**2)
-
-    # Get the angle to one of the corners with respect
-    # to the x-axis.
-    angle = math.atan2(height / 2, width / 2)
-
-    # Transform that angle to reach each corner of the rectangle.
-    angles = [angle, -angle + math.pi, angle + math.pi, -angle]
-
-    # Calculate the coordinates of each point.
-    for angle in angles:
-        y_offset = -1 * radius * math.sin(angle + rotation)
-        x_offset = radius * math.cos(angle + rotation)
-        points.append((x + x_offset, y + y_offset))
-
-    return points
 
 class Env(gym.Env):
     """
@@ -122,13 +72,6 @@ class Env(gym.Env):
         self.device = device
         self.action_types = 3  # Acceleration, steering, and heading
 
-        # Rendering
-        self.render_mode = render_mode
-        self.world_render_idx = 0  # Render only the 0th world
-        self.screen_dim = 1000
-        self.screen = None
-        self.clock = None
-
         # TODO: @AP / @SK: Allow for num_worlds < num_files
         assert num_worlds == len(
             glob.glob(f"{data_dir}/*.json")
@@ -148,6 +91,14 @@ class Env(gym.Env):
             json_path=self.data_dir,
             params=params,
         )
+
+        # Rendering
+        self.render_mode = render_mode
+        self.world_render_idx = 0
+        agent_count = (
+            self.sim.shape_tensor().to_torch()[self.world_render_idx, :][0].item()
+        )
+        self.visualizer = Visualizer(agent_count, self.render_mode == "human")
 
         # We only want to obtain information from vehicles we control
         # By default, the sim returns information for all vehicles in a scene
@@ -200,7 +151,7 @@ class Env(gym.Env):
                     self.action_key_to_values[action_idx]
                 )
 
-        # Feed the actual action values to GPU Drive
+        # Feed the actual action values to gpudrive
         self.sim.action_tensor().to_torch().copy_(action_value_tensor)
 
         # Step the simulator
@@ -339,15 +290,45 @@ class Env(gym.Env):
 
     def render(self):
         """Render the environment."""
+
         def create_render_mask():
-            agent_to_is_valid = (self.sim.valid_state_tensor()
-                .to_torch()[self.world_render_idx, :, :]
-                .cpu()
-                .detach()
-                .numpy()
+
+            valid_mask = (
+                (
+                    self.sim.valid_state_tensor()
+                    .to_torch()[self.world_render_idx, :, :]
+                    .cpu()
+                    .detach()
+                    .numpy()
+                )
+                .squeeze(1)
+                .astype(bool)
             )
 
-            return agent_to_is_valid
+            controlled_mask = (
+                (
+                    self.sim.controlled_state_tensor()
+                    .to_torch()[self.world_render_idx, :, :]
+                    .cpu()
+                    .detach()
+                    .numpy()
+                )
+                .squeeze(1)
+                .astype(bool)
+            )
+
+            agent_count = (
+                self.sim.shape_tensor().to_torch()[self.world_render_idx][0].item()
+            )
+            padding_count = valid_mask.shape[0] - agent_count
+            real_agent_mask = np.concatenate(
+                (np.array([1] * agent_count), np.array([0] * padding_count))
+            )
+
+            return np.logical_or(
+                np.logical_and(real_agent_mask, valid_mask),
+                np.logical_and(real_agent_mask, controlled_mask),
+            )
 
         if self.render_mode is None:
             assert self.spec is not None
@@ -357,26 +338,6 @@ class Env(gym.Env):
                 f'e.g. gym.make("{self.spec.id}", render_mode="rgb_array")'
             )
             return
-        try:
-            import pygame
-
-        except ImportError as e:
-            raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
-            ) from e
-
-        pygame.init()
-        pygame.font.init()
-
-        if self.screen is None and self.render_mode == "human":
-            pygame.display.init()
-            self.screen = pygame.display.set_mode((WINDOW_W, WINDOW_H))
-        if self.clock is None:
-            self.clock = pygame.time.Clock()
-
-        # Create a new canvas to draw on
-        self.surf = pygame.Surface((WINDOW_W, WINDOW_H))
-        self.surf.fill((255, 255, 255))  # White background
 
         # Get agent info
         agent_info = (
@@ -394,91 +355,7 @@ class Env(gym.Env):
 
         render_mask = create_render_mask()
 
-        agent_pos_mean = np.mean(agent_pos, axis=0, where=render_mask==1)
-
-        num_agents_in_scene = np.count_nonzero(goal_pos[:, 0])
-
-        # Draw the agent positions
-        for agent_idx in range(num_agents_in_scene):
-            if not render_mask[agent_idx]:
-                continue
-            
-            # Use the updated scale_coord function to get centered and scaled coordinates
-            current_pos_scaled = self.scale_coords(
-                agent_pos[agent_idx], agent_pos_mean[0], agent_pos_mean[1]
-            )
-
-            current_goal_scaled = self.scale_coords(
-                goal_pos[agent_idx], agent_pos_mean[0], agent_pos_mean[1]
-            )
-
-            mod_idx = agent_idx % len(COLOR_LIST)
-
-            agent_corners = compute_agent_corners(current_pos_scaled, 
-                                                  VEH_WIDTH, 
-                                                  VEH_HEIGHT, 
-                                                  agent_rot[agent_idx])
-
-            pygame.draw.polygon(surface=self.surf,
-                                color=COLOR_LIST[mod_idx],
-                                points=agent_corners)
-
-            pygame.draw.circle(
-                surface=self.surf,
-                color=COLOR_LIST[mod_idx],
-                center=(
-                    int(current_goal_scaled[0]),
-                    int(current_goal_scaled[1]),
-                ),
-                radius=GOAL_RADIUS,
-            )
-
-            # Log
-            agent_log_dict = {
-                "episode_step": 90
-                - self.steps_remaining[self.world_render_idx, 0, 0].item(),
-                f"goal_pos/agent_{agent_idx}_goal_x": goal_pos[agent_idx, 0],
-                f"goal_pos/agent_{agent_idx}_goal_y": goal_pos[agent_idx, 1],
-                f"pos/agent_{agent_idx}_x": agent_pos[agent_idx, 0],
-                f"pos/agent_{agent_idx}_y": agent_pos[agent_idx, 1],
-                f"dist/agent_{agent_idx}_goal_dist": np.linalg.norm(
-                    agent_pos[agent_idx] - goal_pos[agent_idx]
-                ),
-                f"pos_scaled/agent_{agent_idx}_x": current_pos_scaled[0],
-                f"pos_scaled/agent_{agent_idx}_y": current_pos_scaled[1],
-                f"dist_scaled/agent_{agent_idx}_goal_dist": np.linalg.norm(
-                    np.array(current_pos_scaled)
-                    - np.array(current_goal_scaled)
-                ),
-            }
-
-            # wandb.log(agent_log_dict)
-
-        if self.render_mode == "human":
-            pygame.event.pump()
-            self.clock.tick(self.metadata["render_fps"])
-            assert self.screen is not None
-            self.screen.fill(0)
-            self.screen.blit(self.surf, (0, 0))
-            pygame.display.flip()
-        elif self.render_mode == "rgb_array":
-            return self._create_image_array(self.surf)
-        else:
-            return self.isopen
-
-    def scale_coords(
-            self, coords, x_avg, y_avg
-    ):
-        """Scale the coordinates to fit within the pygame surface window and center them.
-        Args:
-            coords: x, y coordinates
-        """
-        x, y = coords
-
-        x_scaled = x - x_avg + (WINDOW_W / 2)
-        y_scaled = y - y_avg + (WINDOW_H / 2)
-
-        return (x_scaled, y_scaled)
+        return self.visualizer.draw(agent_pos, agent_rot, goal_pos, render_mask)
 
     def normalize_ego_state(self, state):
         """Normalize ego state features."""
@@ -490,20 +367,6 @@ class Env(gym.Env):
         state[:, :, 4] /= self.config.max_rel_goal_coords
 
         return state
-
-    def close(self):
-        """Close pygame application if open."""
-        if self.screen is not None:
-            import pygame
-
-            pygame.display.quit()
-            pygame.quit()
-            self.isopen = False
-
-    def _create_image_array(self, surf):
-        return np.transpose(
-            np.array(pygame.surfarray.pixels3d(surf)), axes=(1, 0, 2)
-        )
 
     def _print_info(self, verbose=True):
         """Print initialization information."""
@@ -545,7 +408,7 @@ if __name__ == "__main__":
         num_worlds=1,
         max_cont_agents=NUM_CONT_AGENTS,  # Number of agents to control
         data_dir="/home/samk/gpudrive/waymo_data",
-        device="cuda",
+        device="cpu",
     )
 
     obs = env.reset()
@@ -567,9 +430,9 @@ if __name__ == "__main__":
         # Step the environment
         obs, reward, done, info = env.step(rand_action)
 
-        print(
-            f"speed: {obs[0, 0, 0].item():.2f} | x_pos: {obs[0, 0, 3].item():.2f} | y_pos: {obs[0, 0, 4].item():.2f} | reward:{reward[0].item():.2f} | done: {done[0].item()}\n"
-        )
+        # print(
+        #     f"speed: {obs[0, 0, 0].item():.2f} | x_pos: {obs[0, 0, 3].item():.2f} | y_pos: {obs[0, 0, 4].item():.2f} | reward:{reward[0].item():.2f} | done: {done[0].item()}\n"
+        # )
 
         if done.sum() == NUM_CONT_AGENTS:
             obs = env.reset()
@@ -583,4 +446,4 @@ if __name__ == "__main__":
     # wandb.log({"scene": wandb.Video(np.array(frames), fps=10, format="gif")})
 
     # run.finish()
-    env.close()
+    env.visualizer.destroy()

--- a/pygpudrive/env/viz.py
+++ b/pygpudrive/env/viz.py
@@ -1,0 +1,127 @@
+import pygame
+from pygame import Color
+import numpy as np
+from pygame.sprite import Sprite
+import os
+
+
+class Agent(Sprite):
+    def __init__(self, screen, base_image):
+        Sprite.__init__(self)
+
+        self.screen = screen
+        self.base_image = base_image
+        self.ready_to_draw = False
+
+    def update(self, position, rotation):
+        def to_degrees(r):
+            return r * 180 / np.pi
+
+        # Rotation
+        self.image = pygame.transform.rotate(self.base_image, -to_degrees(rotation))
+        self.image_w, self.image_h = self.image.get_size()
+
+        # Position
+        self.position = position
+
+        self.ready_to_draw = True
+
+    def draw(self):
+        assert self.ready_to_draw
+
+        self.draw_rect = self.image.get_rect().move(
+            self.position[0] - self.image_w / 2, self.position[1] - self.image_h / 2
+        )
+        self.screen.blit(self.image, self.draw_rect)
+
+        self.ready_to_draw = False
+
+
+class Visualizer:
+    WINDOW_W, WINDOW_H = 500, 500
+    VEH_WIDTH, VEH_HEIGHT = 2.05, 4.6
+    GOAL_RADIUS = 2
+    BACKGROUND_COLOR = (0, 0, 0)
+
+    def __init__(self, agent_count, human_render=True):
+        self.human_render = human_render
+
+        pygame.init()
+        pygame.font.init()
+        pygame.display.init()  # TODO(sk): unnecessary?
+
+        # TODO(sk): check depth parameter
+        self.screen = pygame.display.set_mode((self.WINDOW_W, self.WINDOW_H), 0, 32)
+
+        self.clock = pygame.time.Clock()
+
+        self.agent_images = []
+        for base_name in ["green_agent.svg", "pink_agent.svg", "yellow_agent.svg"]:
+            absolute_image_path = os.path.join(
+                os.path.dirname(__file__), "..", "..", "data", base_name
+            )
+            self.agent_images.append(
+                pygame.image.load(absolute_image_path).convert_alpha()
+            )
+
+        self.agents = pygame.sprite.Group()
+        for i in range(agent_count):
+            self.agents.add(
+                Agent(self.screen, self.agent_images[i % len(self.agent_images)])
+            )
+
+        self.colors = [Color("green"), Color("pink"), Color("yellow")]
+
+    def scale_coords(self, coords, x_avg, y_avg):
+        """Scale the coordinates to fit within the pygame surface window and center them.
+        Args:
+            coords: x, y coordinates
+        """
+        x, y = coords
+        x_scaled = x - x_avg + (self.WINDOW_W / 2)
+        y_scaled = y - y_avg + (self.WINDOW_H / 2)
+        return (x_scaled, y_scaled)
+
+    def _create_image_array(self, surf):
+        return np.transpose(np.array(pygame.surfarray.pixels3d(surf)), axes=(1, 0, 2))
+
+    def draw(self, positions, rotations, goals, mask):
+        self.screen.fill(self.BACKGROUND_COLOR)
+
+        # agent_pos_mean = np.mean(positions, axis=0, where=np.expand_dims(mask, axis=1))
+        agent_pos_mean = positions[0]
+
+        for agent_idx, agent in enumerate(self.agents):
+            if not mask[agent_idx]:
+                continue
+
+            # Agent
+            current_pos_scaled = self.scale_coords(
+                positions[agent_idx], agent_pos_mean[0], agent_pos_mean[1]
+            )
+            agent.update(current_pos_scaled, rotations[agent_idx])
+            agent.draw()
+
+            # Goal
+            current_goal_scaled = self.scale_coords(
+                goals[agent_idx], agent_pos_mean[0], agent_pos_mean[1]
+            )
+            pygame.draw.circle(
+                surface=self.screen,
+                color=self.colors[agent_idx % len(self.colors)],
+                center=(
+                    int(current_goal_scaled[0]),
+                    int(current_goal_scaled[1]),
+                ),
+                radius=self.GOAL_RADIUS,
+            )
+
+        if self.human_render:
+            self.clock.tick(30)  # Limit to 30 FPS
+            pygame.display.flip()
+        else:
+            return self._create_image_array(self.screen)
+
+    def destroy(self):
+        pygame.display.quit()
+        pygame.quit()


### PR DESCRIPTION
The primary purpose of this ﻿PR is to rotate agents with pygame so as to eliminate the variable of incorrect manual transformations in debugging agent headings. To this end, the logic in `Env.render()` has been hoisted out into a new `Visualizer` object. The logic to draw a single agent is now encapsulated in an `Agent` object inheriting from `pygame.sprite`. After these changes, agents are drawn with what looks to be the correct heading.

The following TODO items remain:
1. Zooming into agents
2. Scaling agents with their true length and width
3. Factoring out goals into their own sprite class
4. Adding more colors for agents 

