### PR TITLE
Fix collision behaviours

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -265,7 +265,7 @@ inline void movementSystem(Engine &e,
         if(e.data().params.collisionBehaviour == CollisionBehaviour::AgentStop) {
             velocity.linear.x = 0;
             velocity.linear.y = 0;
-            velocity.linear.z = fminf(velocity.linear.z, 0);
+            velocity.linear.z = 0;
             velocity.angular = Vector3::zero();
             done.v = 1;
             return;
@@ -275,7 +275,7 @@ inline void movementSystem(Engine &e,
             position = consts::kPaddingPosition;
             velocity.linear.x = 0;
             velocity.linear.y = 0;
-            velocity.linear.z = fminf(velocity.linear.z, 0);
+            velocity.linear.z = 0;
             velocity.angular = Vector3::zero();
             return;
         }
@@ -359,7 +359,7 @@ inline void agentZeroVelSystem(Engine &,
 {
     vel.linear.x = 0;
     vel.linear.y = 0;
-    vel.linear.z = fminf(vel.linear.z, 0);
+    vel.linear.z = 0;
     vel.angular = Vector3::zero();
 }
 


### PR DESCRIPTION
This PR intends to ignore collisions when objects are teleported away and they are NON VALID EXPERTS. That is they are not padding entities or teleported away because of prior collision. 

Also, smaller changes included here adds a return statement to the teleport condition and zeroes out the velocity of the agent in the agent stop condition (This happens anyways due to the zerovel system but is now explicitly done.) 

Also, adds a small condition to the info tensor if its not updated in the tracking system. 