### PR TITLE
Drop agents beyond consts::kMaxAgentCount

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -850,7 +850,6 @@ Sim::Sim(Engine &ctx,
 {
     // Below check is used to ensure that the map is not empty due to incorrect WorldInit copy to GPU
     assert(init.map->numObjects);
-    assert(init.map->numObjects <= consts::kMaxAgentCount);
     assert(init.map->numRoadSegments <= consts::kMaxRoadEntityCount);
 
     // Currently the physics system needs an upper bound on the number of


### PR DESCRIPTION
This alters the behavior of gpudrive to avoid constructing agents if `consts::kMaxAgentCount` already exist. 