### PR TITLE
Remove render mask and rescale

### DIFF
--- a/pygpudrive/env/viz.py
+++ b/pygpudrive/env/viz.py
@@ -10,7 +10,7 @@ import gpudrive
 class PyGameVisualizer:
     WINDOW_W, WINDOW_H = 1920, 1080
     BACKGROUND_COLOR = (0, 0, 0)
-    PADDING_PCT = 0.1
+    PADDING_PCT = 0.0
     COLOR_LIST = [
         (255, 0, 0),  # Red
         (0, 255, 0),  # Green
@@ -50,6 +50,17 @@ class PyGameVisualizer:
         self.compute_window_settings()
         self.init_map()
 
+    @staticmethod
+    def get_all_endpoints(map_info):
+        centers = map_info[:, :2]
+        lengths = map_info[:, 2]
+        yaws = map_info[:, 5]
+
+        offsets = np.column_stack((lengths * np.cos(yaws), lengths * np.sin(yaws)))
+        starts = centers - offsets
+        ends = centers + offsets
+        return starts, ends
+    
     def compute_window_settings(self):
         map_info = (
             self.sim.map_observation_tensor()
@@ -57,19 +68,25 @@ class PyGameVisualizer:
             .cpu()
             .numpy()
         )
+        map_info = map_info[map_info[:, -1] != float(gpudrive.EntityType.Padding)]
+        roads = map_info[map_info[:, -1] <= float(gpudrive.EntityType.RoadLane)]
+        endpoints = PyGameVisualizer.get_all_endpoints(roads)
 
+        all_endpoints = np.concatenate(endpoints, axis=0)
+        
         # Adjust window dimensions by subtracting padding
-        adjusted_window_width = self.WINDOW_W - self.padding_x
-        adjusted_window_height = self.WINDOW_H - self.padding_y
+        adjusted_window_width = self.WINDOW_W/2 - self.padding_x
+        adjusted_window_height = self.WINDOW_H/2 - self.padding_y
 
         self.zoom_scale_x = adjusted_window_width / (
-            map_info[:, 0].max() - map_info[:, 0].min()
-        )
+            all_endpoints[:, 0].max() - all_endpoints[:, 0].min() 
+        ) 
         self.zoom_scale_y = adjusted_window_height / (
-            map_info[:, 1].max() - map_info[:, 1].min()
-        )
+            all_endpoints[:, 1].max() - all_endpoints[:, 1].min()
+        ) 
 
-        self.window_center = np.mean(map_info, axis=0)
+        self.window_center = np.mean(all_endpoints[:, :2], axis=0)
+        print(f"Window center: {self.window_center}")
 
     def create_render_mask(self):
         agent_to_is_valid = (
@@ -90,13 +107,11 @@ class PyGameVisualizer:
         x, y = coords
         x_scaled = (
             (x - self.window_center[0]) * self.zoom_scale_x
-            + (self.WINDOW_W / 2)
-            + self.padding_x / 2
+            + self.WINDOW_W / 2 - self.padding_x / 2
         )
         y_scaled = (
             (y - self.window_center[1]) * self.zoom_scale_y
-            + (self.WINDOW_H / 2)
-            + self.padding_y / 2
+            + self.WINDOW_H / 2 - self.padding_y / 2
         )
 
         return (x_scaled, y_scaled)
@@ -165,8 +180,10 @@ class PyGameVisualizer:
             .numpy()
         )
 
+        map_info = map_info[map_info[:, -1] != float(gpudrive.EntityType.Padding)]
+
         for idx, map_obj in enumerate(map_info):
-            if map_obj[-1] == float(gpudrive.EntityType._None):
+            if map_obj[-1] == float(gpudrive.EntityType.Padding):
                 continue
             elif map_obj[-1] <= float(gpudrive.EntityType.RoadLane):
                 start, end = PyGameVisualizer.get_endpoints(map_obj[:2], map_obj)
@@ -196,7 +213,6 @@ class PyGameVisualizer:
 
     def draw(self, cont_agent_mask):
         """Render the environment."""
-        render_mask = self.create_render_mask()
         self.surf.fill(self.BACKGROUND_COLOR)
         self.surf.blit(self.map_surf, (0, 0))
         # Get agent info
@@ -218,7 +234,8 @@ class PyGameVisualizer:
 
         # Draw the agent positions
         for agent_idx in range(num_agents_in_scene):
-            if not render_mask[agent_idx]:
+            info_tensor = self.sim.info_tensor().to_torch()[self.world_render_idx]
+            if info_tensor[agent_idx, -1] == float(gpudrive.EntityType.Padding) or info_tensor[agent_idx, -1] == float(gpudrive.EntityType._None):
                 continue
 
             agent_corners = PyGameVisualizer.compute_agent_corners(
@@ -251,7 +268,7 @@ class PyGameVisualizer:
                     int(current_goal_scaled[0]),
                     int(current_goal_scaled[1]),
                 ),
-                radius=self.goal_radius * self.zoom_scale_x,
+                radius=self.goal_radius,
             )
 
         if self.render_mode == "human":

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -298,7 +298,7 @@ static inline Entity createPhysicsEntityPadding(Engine &ctx) {
     ctx.get<MapObservation>(physicsEntity) = MapObservation{.position = ctx.get<Position>(physicsEntity).xy(), 
                                                             .scale = ctx.get<Scale>(physicsEntity),
                                                             .heading = utils::quatToYaw(ctx.get<Rotation>(physicsEntity)), 
-                                                            .type = 0};
+                                                            .type = float(EntityType::Padding)};
     ctx.get<EntityType>(physicsEntity) = EntityType::Padding;
 
     return physicsEntity;

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -52,7 +52,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerComponent<Info>();
     registry.registerSingleton<WorldReset>();
     registry.registerSingleton<Shape>();
-    registry.registerSingleton<ValidState>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
@@ -60,7 +59,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<WorldReset>(
         (uint32_t)ExportID::Reset);
     registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
-    registry.exportSingleton<ValidState>((uint32_t)ExportID::ValidState);
     registry.exportColumn<Agent, Action>(
         (uint32_t)ExportID::Action);
     registry.exportColumn<Agent, SelfObservation>(
@@ -670,29 +668,6 @@ inline void collectAbsoluteObservationsSystem(Engine &ctx,
     out.vehicle_size = vehicleSize;
 }
 
-inline void validStateSystem(Engine &ctx, ValidState &validOut) {
-    // This assumes StepsRemaining is constant across all agents
-    Entity anyAgent = ctx.data().agents[0];
-    const auto stepsRemaining = ctx.get<StepsRemaining>(anyAgent);
-    const CountT currentStep = getCurrentStep(stepsRemaining);
-
-    for (CountT agentIdx = 0; agentIdx < ctx.data().numAgents; ++agentIdx) {
-        auto agentHandle = ctx.data().agents[agentIdx];
-        const auto &trajectory = ctx.get<Trajectory>(agentHandle);
-
-        assert(currentStep < consts::kTrajectoryLength);
-        int32_t isValid = trajectory.valids[currentStep];
-
-        validOut.valid[agentIdx] = static_cast<Validity>(isValid);
-    }
-
-    for (CountT agentIdx = ctx.data().numAgents;
-         agentIdx < consts::kMaxAgentCount; ++agentIdx) {
-        auto agentHandle = ctx.data().agents[agentIdx];
-        validOut.valid[agentIdx] = Validity::Invalid;
-    }
-}
-
 // Build the task graph
 void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
 {
@@ -715,17 +690,12 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
             Done
         >>({});
 
-    auto updateValidStateSystem =
-        builder
-            .addToGraph<ParallelForNode<Engine, validStateSystem, ValidState>>(
-                {moveSystem});
-
     // setupBroadphaseTasks consists of the following sub-tasks:
     // 1. updateLeafPositionsEntry
     // 2. broadphase::updateBVHEntry
     // 3. broadphase::refitEntry
     auto broadphase_setup_sys = phys::PhysicsSystem::setupBroadphaseTasks(
-        builder, {updateValidStateSystem});
+        builder, {moveSystem});
 
     auto findOverlappingEntities =
         phys::PhysicsSystem::setupBroadphaseOverlapTasks(

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -215,15 +215,6 @@ const size_t AbsoluteSelfObservationExportSize =  12; //  3 + 4 + 1 + 2
 
 static_assert(sizeof(AbsoluteSelfObservation) == sizeof(float) * AbsoluteSelfObservationExportSize);
 
-enum class Validity : int32_t {
-    Invalid = 0,
-    Valid = 1
-};
-
-struct ValidState {
-    Validity valid[consts::kMaxAgentCount];
-};
-
 /* ECS Archetypes for the game */
 
 // There are 2 Agents in the environment trying to get to the destination


### PR DESCRIPTION
1. Rescale according to non-padding map objs. 
2. We remove render mask based on valid state. The reason is that we should not remove agents based on whether they are valid in the expert trajectory. Agents can be valid/invalid independent of what their state in the expert trajectories are. I also removed the valid state system since it was only introduced for this specific purpose. 

Bugs introduced - While the renders are correct, but there is a zoom out effect. Currently we scale by (w/2, h/2) so that the entire maps fits in. One can change it to (w, h) or (w/1.25, h/1.25) based on how zoomed in you want the render. However, the more you zoom in the more chances to lose maps on the edges. 