### PR TITLE
give envs a fake step to handle the step that must occur after reset

### DIFF
--- a/algorithms/sb3/ppo/ippo.py
+++ b/algorithms/sb3/ppo/ippo.py
@@ -390,6 +390,7 @@ class IPPO(PPO):
         self.logger.record(
             "train/mean_abs_advantages", advantages.abs().mean().item()
         )
+        self.logger.record("train/explained_variance", explained_var.item())
         self.logger.record("train/policy_gradient_loss", np.mean(pg_losses))
         self.logger.record("train/value_loss", np.mean(value_losses))
         self.logger.record("train/approx_kl", np.mean(approx_kl_divs))

--- a/pygpudrive/env/wrappers/sb3_wrapper.py
+++ b/pygpudrive/env/wrappers/sb3_wrapper.py
@@ -179,8 +179,8 @@ class SB3MultiAgentEnv(VecEnv):
         
         # Now override the dead agent mask for the reset worlds
         if self.world_ready.any().item():
-            self.dead_agent_mask[done_worlds] = ~self.controlled_agent_mask[done_worlds].clone()
-            self.tot_reward_per_episode[done_worlds] = 0
+            self.dead_agent_mask[self.world_ready] = ~self.controlled_agent_mask[done_worlds].clone()
+            self.tot_reward_per_episode[self.world_ready] = 0
 
         return (
             obs[self.controlled_agent_mask].reshape(self.num_envs, self.obs_dim).clone(),

--- a/pygpudrive/env/wrappers/sb3_wrapper.py
+++ b/pygpudrive/env/wrappers/sb3_wrapper.py
@@ -61,7 +61,7 @@ class SB3MultiAgentEnv(VecEnv):
         # because we have to step the environment after it resets before it is ready
         # environments after reset cannot be used for an additional step.
         # we want the dead agent mask to remain dead until after that happens
-        self.world_ready = torch.ones((self.num_worlds, self.max_agent_count)).to(self.device)
+        self.world_ready = torch.ones((self.num_worlds, self.max_agent_count), dtype=torch.bool).to(self.device)
         self.actions_tensor = torch.zeros((self.num_worlds, self.max_agent_count)).to(self.device)
         # Storage: Fill buffer with nan values
         self.buf_rews = torch.full(
@@ -179,7 +179,7 @@ class SB3MultiAgentEnv(VecEnv):
         
         # Now override the dead agent mask for the reset worlds
         if self.world_ready.any().item():
-            self.dead_agent_mask[self.world_ready] = ~self.controlled_agent_mask[done_worlds].clone()
+            self.dead_agent_mask[self.world_ready] = ~self.controlled_agent_mask[self.world_ready].clone()
             self.tot_reward_per_episode[self.world_ready] = 0
 
         return (


### PR DESCRIPTION
After an env is reset, we need to call step on it before it is ready for actions. However, we can't call step just on it so for reset envs, they need an extra step before they are ready to generate experience. This attempts to handle that case.