### PR TITLE
Remove bicycle model struct

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -103,7 +103,6 @@ namespace gpudrive
             .def("action_tensor", &Manager::actionTensor)
             .def("reward_tensor", &Manager::rewardTensor)
             .def("done_tensor", &Manager::doneTensor)
-            .def("bicycle_model_tensor", &Manager::bicycleModelTensor)
             .def("self_observation_tensor", &Manager::selfObservationTensor)
             .def("map_observation_tensor", &Manager::mapObservationTensor)
             .def("partner_observations_tensor", &Manager::partnerObservationsTensor)

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -79,7 +79,6 @@ int main(int argc, char *argv[])
     std::uniform_real_distribution<float> steer_gen(-0.7,0.7);
 
     auto action_printer = mgr.actionTensor().makePrinter();
-    auto model_printer = mgr.bicycleModelTensor().makePrinter();
     auto self_printer = mgr.selfObservationTensor().makePrinter();
     auto partner_obs_printer = mgr.partnerObservationsTensor().makePrinter();
     auto map_obs_printer = mgr.mapObservationTensor().makePrinter();
@@ -96,9 +95,6 @@ int main(int argc, char *argv[])
 
         // printf("Actions\n");
         // action_printer.print();
-
-        printf("Model \n");
-        model_printer.print();
 
         // printf("Partner Obs\n");
         // partner_obs_printer.print();

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -28,8 +28,6 @@ static inline void resetAgent(Engine &ctx, Entity agent) {
     auto speed = ctx.get<Trajectory>(agent).velocities[0].length();
     auto heading = ctx.get<Trajectory>(agent).headings[0];
 
-    ctx.get<BicycleModel>(agent) = {
-        .position = {.x = xCoord, .y = yCoord}, .heading = heading, .speed = speed};
     ctx.get<Position>(agent) = Vector3{.x = xCoord, .y = yCoord, .z = 1};
     ctx.get<Rotation>(agent) = Quat::angleAxis(heading, madrona::math::up);
     ctx.get<Velocity>(agent) = {

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -673,17 +673,6 @@ Tensor Manager::actionTensor() const
         });
 }
 
-Tensor Manager::bicycleModelTensor() const
-{
-    return impl_->exportTensor(ExportID::BicycleModel, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds,
-            consts::kMaxAgentCount,
-            BicycleModelExportSize, // Number of states for the bicycle model
-        });
-}
-
-
 Tensor Manager::rewardTensor() const
 {
     return impl_->exportTensor(ExportID::Reward, TensorElementType::Float32,

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -58,7 +58,6 @@ public:
     MGR_EXPORT madrona::py::Tensor agentMapObservationsTensor() const;
     MGR_EXPORT madrona::py::Tensor lidarTensor() const;
     MGR_EXPORT madrona::py::Tensor stepsRemainingTensor() const;
-    MGR_EXPORT madrona::py::Tensor bicycleModelTensor() const;
     MGR_EXPORT madrona::py::Tensor shapeTensor() const;
     MGR_EXPORT madrona::py::Tensor controlledStateTensor() const;
     MGR_EXPORT madrona::py::Tensor absoluteSelfObservationTensor() const;

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -36,16 +36,6 @@ enum class EntityType : uint32_t {
     NumTypes,
 };
 
-struct BicycleModel {
-    madrona::math::Vector2 position;
-    float heading;
-    float speed;
-};
-
-const size_t BicycleModelExportSize = 4;
-
-static_assert(sizeof(BicycleModel) == sizeof(float) * BicycleModelExportSize);
-
 struct VehicleSize {
   float length;
   float width;
@@ -244,7 +234,6 @@ struct Agent : public madrona::Archetype<
     EntityType,
 
     // gpudrive
-    BicycleModel,
     VehicleSize,
     Goal,
     Trajectory,

--- a/tests/bicyclemodel.cpp
+++ b/tests/bicyclemodel.cpp
@@ -45,6 +45,7 @@ protected:
     std::default_random_engine generator;
     std::uniform_real_distribution<float> acc_distribution;
     std::uniform_real_distribution<float> steering_distribution; 
+    madrona::py::Tensor::Printer absolute_obs_printer =  mgr.absoluteSelfObservationTensor().makePrinter();
     void SetUp() override {
         json rawJson;
         data >> rawJson;
@@ -63,7 +64,9 @@ protected:
             agent_width_map[n_agents] = (float)obj["width"];
             initialState.push_back(float(obj["position"][0]["x"]) - mean.first);
             initialState.push_back(float(obj["position"][0]["y"]) - mean.second);
-            initialState.push_back(test_utils::degreesToRadians(obj["heading"][0]));
+            auto theta = std::fmod(test_utils::degreesToRadians(obj["heading"][0]), M_PI*2);
+            theta = theta > M_PI ? theta -  M_PI*2 : (theta < - M_PI ? theta +  M_PI*2 : theta);
+            initialState.push_back(theta);
             initialState.push_back(math::Vector2{.x = obj["velocity"][0]["x"], .y = obj["velocity"][0]["y"]}.length());
             n_agents++;
         }
@@ -92,11 +95,110 @@ std::tuple<float, float, float, float> StepBicycleModel(float x, float y, float 
     float theta_next = std::fmod(theta + w * dt, M_PI*2); // Clipping necessary to follow the implementation in madrona
     theta_next = theta_next > M_PI ? theta_next -  M_PI*2 : (theta_next < - M_PI ? theta_next +  M_PI*2 : theta_next);
     
-    float speed_next = speed_curr + acceleration * dt;
+    float speed_next = abs(speed_curr + acceleration * dt);
     return std::make_tuple(x_next, y_next, theta_next, speed_next);
 }
 
+std::pair<bool, std::string> validateBicycleModel(const py::Tensor &abs_obs, const py::Tensor &self_obs, const std::vector<float> &expected, const uint32_t num_agents)
+{
+    int64_t num_elems = 1;
+    for (int i = 0; i < abs_obs.numDims(); i++)
+    {
+        num_elems *= abs_obs.dims()[i];
+    }
+
+    if (num_agents * gpudrive::AbsoluteSelfObservationExportSize > num_elems)
+    {
+        return {false, "Expected number of elements is less than the number of agents."};
+    }
+
+    num_elems = 1;
+    for (int i = 0; i < self_obs.numDims(); i++)
+    {
+        num_elems *= self_obs.dims()[i];
+    }
+
+    if (num_agents * gpudrive::SelfObservationExportSize > num_elems)
+    {
+        return {false, "Expected number of elements is less than the number of agents."};
+    }
+
+    float *ptr = static_cast<float *>(abs_obs.devicePtr());
+
+    for (int64_t i = 0, agent_idx = 0; i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;)
+    {
+        auto x = static_cast<float>(ptr[i]);
+        auto y = static_cast<float>(ptr[i + 1]);
+        auto rot = static_cast<float>(ptr[i + 7]);
+        auto x_exp = expected[agent_idx];
+        auto y_exp = expected[agent_idx + 1];
+        auto rot_exp = expected[agent_idx + 2];
+
+        i += gpudrive::AbsoluteSelfObservationExportSize;
+        agent_idx += 4;
+
+        if (std::abs(x - x_exp) > test_utils::EPSILON || std::abs(y - y_exp) > test_utils::EPSILON || std::abs(rot - rot_exp) > test_utils::EPSILON)
+        {
+            return {false, "Value mismatch."};
+        }
+    }
+    
+    ptr = static_cast<float *>(self_obs.devicePtr());
+    for (int64_t i = 0, agent_idx = 0; i < num_agents * gpudrive::SelfObservationExportSize;)
+    {
+        auto speed = static_cast<float>(ptr[i]);
+        auto speed_exp = expected[agent_idx+3];
+
+        if(std::abs(speed - speed_exp) > test_utils::EPSILON)
+        {
+            return {false, "Value mismatch."};
+        }
+
+        agent_idx += 4;
+        i += gpudrive::SelfObservationExportSize;
+    }
+
+    return {true, ""};
+}
+
+std::vector<float> parseBicycleModel(const py::Tensor &abs_obs, const py::Tensor &self_obs, const uint32_t num_agents)
+{
+    std::vector<float> obs;
+    obs.resize(num_agents * 4);
+    float *ptr = static_cast<float *>(abs_obs.devicePtr());
+    for (int i = 0, agent_idx = 0; i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;)
+    {
+        obs[agent_idx] = static_cast<float>(ptr[i]);
+        obs[agent_idx+1] = static_cast<float>(ptr[i+1]);
+        obs[agent_idx+2] = static_cast<float>(ptr[i+7]);
+        agent_idx += 4;
+        i+=gpudrive::AbsoluteSelfObservationExportSize;
+    }
+    ptr = static_cast<float *>(self_obs.devicePtr());
+    for (int i = 0, agent_idx = 0; i < num_agents * gpudrive::SelfObservationExportSize;)
+    {
+        obs[agent_idx+3] = static_cast<float>(ptr[i]);
+        agent_idx += 4;
+        i+=gpudrive::SelfObservationExportSize;
+    }
+    return obs;
+}
+
 TEST_F(BicycleKinematicModelTest, TestModelEvolution) {
+
+    auto printObs = [&]() {
+        printf("Absolute: \n");
+        absolute_obs_printer.print();
+        printf("\n");
+    };
+
+    auto printVector = [](const std::vector<float>& v) {
+        std::cout << "Vector: \n";
+        for(auto i : v) {
+            std::cout << i << " ";
+        }
+        std::cout << "\n";
+    };
     std::vector<float> expected;
     //Check first step -
     for(int i = 0; i < num_agents; i++)
@@ -107,14 +209,18 @@ TEST_F(BicycleKinematicModelTest, TestModelEvolution) {
         expected.push_back(theta_next);
         expected.push_back(speed_next);
     }
-    auto obs = mgr.bicycleModelTensor();
-    auto [valid, errorMsg] = test_utils::validateTensor(obs, initialState, num_agents);
+    auto abs_obs = mgr.absoluteSelfObservationTensor();
+    auto self_obs = mgr.selfObservationTensor();
+    auto [valid, errorMsg] = validateBicycleModel(abs_obs, self_obs, initialState, num_agents);
     ASSERT_TRUE(valid);
+    printObs();
     
     for(int i = 0; i < num_steps; i++)
     {
         expected.clear();
-        auto prev_state = test_utils::flatten_obs(obs); // Due to floating point errors, we cannot use the expected values from the previous step so as not to accumulate errors.
+        printObs();
+        auto prev_state = parseBicycleModel(abs_obs, self_obs, num_agents); // Due to floating point errors, we cannot use the expected values from the previous step so as not to accumulate errors.
+        printVector(prev_state);
         for(int j = 0; j < num_agents; j++)
         {
             float acc =  acc_distribution(generator);
@@ -127,11 +233,10 @@ TEST_F(BicycleKinematicModelTest, TestModelEvolution) {
             expected.push_back(speed_next);
         }
         mgr.step();
-        obs = mgr.bicycleModelTensor(); 
-        std::tie(valid, errorMsg) = test_utils::validateTensor(obs, expected, num_agents);
+        abs_obs = mgr.absoluteSelfObservationTensor(); 
+        self_obs = mgr.selfObservationTensor();
+        std::tie(valid, errorMsg) = validateBicycleModel(abs_obs, self_obs, expected, num_agents);
         ASSERT_TRUE(valid);
     }
 
 }
-
-

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -9,71 +9,7 @@ using namespace madrona;
 namespace test_utils
 {
     const float EPSILON = 0.001f; // Decreased epsilon to account for floating point errors. TODO: increase floating point precision and ideally use 1e-6 as epsilon.
-
-    template <typename T>
-    std::pair<bool, std::string> validateTensor(const py::Tensor &tensor, const std::vector<T> &expected, const uint32_t num_agents)
-    {
-        int64_t num_elems = 1;
-        for (int i = 0; i < tensor.numDims(); i++)
-        {
-            num_elems *= tensor.dims()[i];
-        }
-
-        if (num_agents * gpudrive::BicycleModelExportSize > num_elems)
-        {
-            return {false, "Expected number of elements is less than the number of agents."};
-        }
-
-        if constexpr (std::is_same<T, int64_t>::value)
-        {
-            if (tensor.type() != py::TensorElementType::Int64)
-            {
-                return {false, "Type mismatch: Expected Int64."};
-            }
-        }
-        else if constexpr (std::is_same<T, float>::value)
-        {
-            if (tensor.type() != py::TensorElementType::Float32)
-            {
-                return {false, "Type mismatch: Expected Float32."};
-            }
-        }
-
-        switch (tensor.type())
-        {
-        case py::TensorElementType::Int64:
-        {
-            int64_t *ptr = static_cast<int64_t *>(tensor.devicePtr());
-            for (int64_t i = 0; i < num_agents * gpudrive::BicycleModelExportSize; ++i)
-            {
-                if (std::abs(ptr[i] - static_cast<int64_t>(expected[i])) > EPSILON)
-                {
-                    return {false, "Value mismatch."};
-                }
-            }
-            break;
-        }
-        case py::TensorElementType::Float32:
-        {
-            float *ptr = static_cast<float *>(tensor.devicePtr());
-            for (int64_t i = 0; i < num_agents * gpudrive::BicycleModelExportSize; ++i)
-            {
-                auto orig = static_cast<float>(ptr[i]);
-                auto exp = expected[i];
-                if (std::abs(orig - exp) > EPSILON)
-                {
-                    return {false, "Value mismatch."};
-                }
-            }
-            break;
-        }
-        default:
-            return {false, "Unhandled data type!"};
-        }
-
-        return {true, ""};
-    }
-
+    
     std::vector<float> flatten_obs(const py::Tensor &obs);
 
     float degreesToRadians(float degrees);


### PR DESCRIPTION
Removing the bicycle model struct in favor of using position, velocity and rotation components directly. One side effect to doing this is removal of `AgentZeroVelSystem` from the taskgraph since we cannot discard previous velocities as they are needed. 
Note - I have still kept the system in code but not using it in task graph. The reason is I aim to reuse it in waymax model PR and also everywhere we need to zero out the velocities. 