### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_compile_options(-Wall -Wextra -Werror)
+
 set(SIMULATOR_SRCS
     types.hpp
     sim.hpp sim.cpp

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -56,74 +56,26 @@ int main(int argc, char *argv[])
         }
     }
 
-    Manager mgr({
-        .execMode = exec_mode,
-        .gpuID = 0,
-        .numWorlds = (uint32_t)num_worlds,
-        .jsonPath = "tests/testJsons",
-        .params = {
-            .polylineReductionThreshold = 1.0,
-            .observationRadius = 100.0,
-            .rewardParams = {
-                .rewardType = RewardType::DistanceBased,
-                .distanceToGoalThreshold = 0.5,
-                .distanceToExpertThreshold = 0.5
-            },
-            .maxNumControlledVehicles = 0,
-        }
-    });
+    Manager mgr({.execMode = exec_mode,
+                 .gpuID = 0,
+                 .numWorlds = (uint32_t)num_worlds,
+                 .jsonPath = "tests/testJsons",
+                 .params = {
+                     .polylineReductionThreshold = 1.0,
+                     .observationRadius = 100.0,
+                     .rewardParams = {.rewardType = RewardType::DistanceBased,
+                                      .distanceToGoalThreshold = 0.5,
+                                      .distanceToExpertThreshold = 0.5},
+                     .datasetInitOptions = DatasetInitOptions::ExactN,
+                     .maxNumControlledVehicles = 0,
+                 }});
 
     std::random_device rd;
     std::mt19937 rand_gen(rd());
     std::uniform_real_distribution<float> acc_gen(-3.0,2.0);
     std::uniform_real_distribution<float> steer_gen(-0.7,0.7);
 
-    auto action_printer = mgr.actionTensor().makePrinter();
-    auto self_printer = mgr.selfObservationTensor().makePrinter();
-    auto partner_obs_printer = mgr.partnerObservationsTensor().makePrinter();
-    auto map_obs_printer = mgr.mapObservationTensor().makePrinter();
-    auto shapePrinter = mgr.shapeTensor().makePrinter();
-    auto rewardPrinter = mgr.rewardTensor().makePrinter();
-    auto donePrinter = mgr.doneTensor().makePrinter();
-    auto controlledStatePrinter = mgr.controlledStateTensor().makePrinter();
-    auto agent_map_obs_printer = mgr.agentMapObservationsTensor().makePrinter();
-    auto info_printer = mgr.infoTensor().makePrinter();
-
-    auto printObs = [&]() {
-        // printf("Self\n");
-        // self_printer.print();
-
-        // printf("Actions\n");
-        // action_printer.print();
-
-        // printf("Partner Obs\n");
-        // partner_obs_printer.print();
-
-        // printf("Map Obs\n");
-        // map_obs_printer.print();
-        // printf("\n");
-
-        // printf("Shape\n");
-        // shapePrinter.print();
-
-        // printf("Reward\n");
-        // rewardPrinter.print();
-
-        // printf("Done\n");
-        // donePrinter.print();
-
-        // printf("Controlled State\n");
-        // controlledStatePrinter.print();
-
-        printf("Agent Map Obs\n");
-        agent_map_obs_printer.print();
-
-        printf("Info\n");
-        info_printer.print();
-    };
-
-    auto worldToShape =
-	mgr.getShapeTensorFromDeviceMemory(exec_mode, num_worlds);
+    auto worldToShape = mgr.getShapeTensorFromDeviceMemory(num_worlds);
 
     const auto start = std::chrono::steady_clock::now();
     for (CountT i = 0; i < (CountT)num_steps; i++) {

--- a/src/init.hpp
+++ b/src/init.hpp
@@ -106,16 +106,16 @@ namespace gpudrive
         float observationRadius;
         RewardParams rewardParams;
         DatasetInitOptions datasetInitOptions;
-        CollisionBehaviour collisionBehaviour = CollisionBehaviour::AgentStop; // Default: AgentStop
+        CollisionBehaviour collisionBehaviour = CollisionBehaviour::AgentStop;
         uint32_t maxNumControlledVehicles = 10000; // Arbitrary high number to by default control all vehicles 
-        bool IgnoreNonVehicles = false; // Default: false
+        bool IgnoreNonVehicles = false;
         FindRoadObservationsWith roadObservationAlgorithm{
             FindRoadObservationsWith::KNearestEntitiesWithRadiusFiltering};
-        bool initOnlyValidAgentsAtFirstStep = true; // Default: true
-        bool isStaticAgentControlled = false; // Default: false
+        bool initOnlyValidAgentsAtFirstStep = true;
+        bool isStaticAgentControlled = false;
         bool enableLidar = false;
         bool disableClassicalObs = false;
-        bool useWayMaxModel = false; // Default: false
+        bool useWayMaxModel = false;
     };
 
     struct WorldInit

--- a/src/json_serialization.hpp
+++ b/src/json_serialization.hpp
@@ -2,7 +2,7 @@
 
 #include "init.hpp"
 #include "types.hpp"
-#include <iostream>
+#include <cstddef>
 #include <nlohmann/json.hpp>
 
 namespace gpudrive
@@ -13,10 +13,7 @@ namespace gpudrive
         p.y = j.at("y").get<float>();
     }
 
-    void from_json(const nlohmann::json &j, MapObject &obj)
-    {
-        const auto &valid = j.at("valid");
-
+    void from_json(const nlohmann::json &j, MapObject &obj) {
         obj.mean = {0,0};
         uint32_t i = 0;
         for (const auto &pos : j.at("position"))
@@ -180,8 +177,7 @@ namespace gpudrive
                 }
                 k++;
             }
-            for (int i = 0; i < new_geometry_points.size(); i++)
-            {
+            for (std::size_t i = 0; i < new_geometry_points.size(); i++) {
                 if(i==MAX_GEOMETRY)
                     break;
                 road.geometry[i] = new_geometry_points[i]; // Create the road lines
@@ -190,21 +186,18 @@ namespace gpudrive
         }
         else
         {
-            for (int64_t i = 0; i < num_sampled_points ; ++i)
-            {
+            for (int64_t i = 0; i < num_sampled_points; ++i) {
                 if(i==MAX_GEOMETRY)
                     break;
-                road.geometry[i] = geometry_points_[i * sample_every_n_]; 
+                road.geometry[i] = geometry_points_[i * sample_every_n_];
             }
             road.numPoints = num_sampled_points;
         }
 
-        for (int i = 0; i < road.numPoints; i++)
-        {
+        for (std::size_t i = 0; i < road.numPoints; i++) {
             road.mean.x += (road.geometry[i].x - road.mean.x)/(i+1);
             road.mean.y += (road.geometry[i].y - road.mean.y)/(i+1);
         }
-
     }
 
     std::pair<float, float> calc_mean(const nlohmann::json &j)
@@ -270,4 +263,4 @@ namespace gpudrive
         }
         map.numRoadSegments = countRoadPoints;
     }
-}
+    } // namespace gpudrive

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -26,7 +26,6 @@ static inline void resetAgent(Engine &ctx, Entity agent) {
     auto yCoord = ctx.get<Trajectory>(agent).positions[0].y;
     auto xVelocity = ctx.get<Trajectory>(agent).velocities[0].x;
     auto yVelocity = ctx.get<Trajectory>(agent).velocities[0].y;
-    auto speed = ctx.get<Trajectory>(agent).velocities[0].length();
     auto heading = ctx.get<Trajectory>(agent).headings[0];
 
     ctx.get<Position>(agent) = Vector3{.x = xCoord, .y = yCoord, .z = 1};
@@ -268,19 +267,6 @@ static inline void createRoadEntities(Engine &ctx, const MapRoad &roadInit, Coun
     }
 }
 
-static void createFloorPlane(Engine &ctx)
-{
-    ctx.data().floorPlane = ctx.makeRenderableEntity<PhysicsEntity>();
-    ctx.get<Position>(ctx.data().floorPlane) = Vector3{.x = 0, .y = 0, .z = 0};
-    ctx.get<Rotation>(ctx.data().floorPlane) = Quat { 1, 0, 0, 0 };
-    ctx.get<Scale>(ctx.data().floorPlane) = Diag3x3{1, 1, 1};
-    ctx.get<ObjectID>(ctx.data().floorPlane) = ObjectID{(int32_t)SimObject::Plane};
-    ctx.get<Velocity>(ctx.data().floorPlane) = {Vector3::zero(), Vector3::zero()};
-    ctx.get<ResponseType>(ctx.data().floorPlane) = ResponseType::Static;
-    ctx.get<EntityType>(ctx.data().floorPlane) = EntityType::None;
-    registerRigidBodyEntity(ctx, ctx.data().floorPlane, SimObject::Plane);
-}
-
 static inline Entity createAgentPadding(Engine &ctx) {
     auto agent = ctx.makeRenderableEntity<Agent>();
 
@@ -350,8 +336,6 @@ void createCameraEntity(Engine &ctx)
 }
 
 void createPersistentEntities(Engine &ctx, Map *map) {
-    // createFloorPlane(ctx);
-
     if (ctx.data().enableRender)
     {
         createCameraEntity(ctx);

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -12,13 +12,13 @@
 
 #include <array>
 #include <charconv>
-#include <iostream>
-#include <iterator>
+#include <cstddef>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <string>
-#include <cstdlib>
+#include <iterator>
 #include <random>
+#include <string>
 
 #ifdef MADRONA_CUDA_SUPPORT
 #include <madrona/mw_gpu.hpp>
@@ -343,9 +343,8 @@ static void loadPhysicsObjects(PhysicsLoader &loader)
         .muD = 0.5f,
     });
 
-    SourceCollisionPrimitive plane_prim {
-        .type = CollisionPrimitive::Type::Plane,
-    };
+    SourceCollisionPrimitive plane_prim{.type = CollisionPrimitive::Type::Plane,
+                                        .plane = {}};
 
     src_objs[(CountT)SimObject::Plane] = {
         .prims = Span<const SourceCollisionPrimitive>(&plane_prim, 1),
@@ -421,9 +420,8 @@ static std::vector<std::string> getMapFiles(const Manager::Config &cfg)
     {
         assert(cfg.numWorlds >= mapFiles.size());
         auto numFiles = mapFiles.size();
-        for(int i = mapFiles.size(); i < cfg.numWorlds; i++)
-        {
-            mapFiles.push_back(mapFiles[i % numFiles]);
+        for (std::size_t i = mapFiles.size(); i < cfg.numWorlds; i++) {
+          mapFiles.push_back(mapFiles[i % numFiles]);
         }
     }
     else if(cfg.params.datasetInitOptions == DatasetInitOptions::ExactN)
@@ -868,9 +866,7 @@ void Manager::setAction(int32_t world_idx, int32_t agent_idx,
     }
 }
 
-std::vector<Shape>
-Manager::getShapeTensorFromDeviceMemory(madrona::ExecMode mode,
-                                        uint32_t numWorlds) {
+std::vector<Shape> Manager::getShapeTensorFromDeviceMemory(uint32_t numWorlds) {
     const auto &tensor = shapeTensor();
 
     const std::size_t floatsPerShape{2};

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -76,7 +76,7 @@ public:
 
     // TODO: remove parameters
     MGR_EXPORT std::vector<Shape>
-    getShapeTensorFromDeviceMemory(madrona::ExecMode mode, uint32_t numWorlds);
+    getShapeTensorFromDeviceMemory(uint32_t numWorlds);
 
     madrona::render::RenderManager & getRenderManager();
 

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -37,7 +37,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerComponent<AgentMapObservations>();
     registry.registerComponent<Reward>();
     registry.registerComponent<Done>();
-    registry.registerComponent<Progress>();
     registry.registerComponent<OtherAgents>();
     registry.registerComponent<PartnerObservations>();
     registry.registerComponent<Lidar>();
@@ -91,8 +90,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
         (uint32_t)ExportID::Trajectory);
 }
 
-static inline void cleanupWorld(Engine &ctx) {}
-
 static inline void initWorld(Engine &ctx)
 {
     phys::PhysicsSystem::reset(ctx);
@@ -117,7 +114,6 @@ inline void resetSystem(Engine &ctx, WorldReset &reset)
     }
 
     reset.reset = 0;
-    cleanupWorld(ctx);
     initWorld(ctx);
 }
 
@@ -129,7 +125,6 @@ inline void collectObservationsSystem(Engine &ctx,
                                       const Rotation &rot,
                                       const Velocity &vel,
                                       const Goal &goal,
-                                      const Progress &progress,
                                       const OtherAgents &other_agents,
                                       SelfObservation &self_obs,
                                       PartnerObservations &partner_obs,
@@ -399,9 +394,7 @@ inline void lidarSystem(Engine &ctx, Entity e, Lidar &lidar,
 // distance achieved.
 inline void rewardSystem(Engine &ctx,
                          const Position &position,
-                         const Trajectory &trajectory,
                          const Goal &goal,
-                         Progress &progress,
                          Reward &out_reward)
 {
 
@@ -428,29 +421,6 @@ inline void rewardSystem(Engine &ctx,
     // out_reward.v = fmaxf(fminf(out_reward.v, 1.f), 0.f);
 }
 
-// Each agent gets a small bonus to it's reward if the other agent has
-// progressed a similar distance, to encourage them to cooperate.
-// This system reads the values of the Progress component written by
-// rewardSystem for other agents, so it must run after.
-inline void bonusRewardSystem(Engine &ctx,
-                              OtherAgents &others,
-                              Progress &progress,
-                              Reward &reward)
-{
-    bool partners_close = true;
-    for (CountT i = 0; i < ctx.data().numAgents - 1; i++) {
-        Entity other = others.e[i];
-        Progress other_progress = ctx.get<Progress>(other);
-
-        if (fabsf(other_progress.maxY - progress.maxY) > 2.f) {
-            partners_close = false;
-        }
-    }
-
-    if (partners_close && reward.v > 0.f) {
-        reward.v *= 1.25f;
-    }
-}
 
 // Keep track of the number of steps remaining in the episode and
 // notify training that an episode has completed by
@@ -629,7 +599,7 @@ TaskGraph::NodeID queueSortByWorld(TaskGraph::Builder &builder,
 }
 #endif
 
-inline void collectAbsoluteObservationsSystem(Engine &ctx,
+inline void collectAbsoluteObservationsSystem(Engine &/* ctx */,
                                               const Position &position,
                                               const Rotation &rotation,
                                               const Goal &goal,
@@ -694,9 +664,7 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
     auto reward_sys = builder.addToGraph<ParallelForNode<Engine,
          rewardSystem,
             Position,
-            Trajectory,
             Goal,
-            Progress,
             Reward
         >>({phys_done});
 
@@ -738,7 +706,6 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
             Rotation,
             Velocity,
             Goal,
-            Progress,
             OtherAgents,
             SelfObservation,
 	        PartnerObservations,

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -153,11 +153,6 @@ struct StepsRemaining {
     uint32_t t;
 };
 
-// Can be refactored for rewards
-struct Progress {
-    float maxY;
-};
-
 // Per-agent component storing Entity IDs of the other agents. Used to
 // build the egocentric observations of their state.
 struct OtherAgents {
@@ -234,7 +229,6 @@ struct Agent : public madrona::Archetype<
     CollisionDetectionEvent,
   
     // Internal logic state.
-    Progress,
     OtherAgents,
     EntityType,
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -28,7 +28,7 @@ class ReferenceFrame {
 public:
   ReferenceFrame(const madrona::math::Vector2 &position,
                  const madrona::base::Rotation &rotation)
-      : referenceRotation(rotation), referencePosition(position) {}
+      : referencePosition(position), referenceRotation(rotation) {}
 
   gpudrive::MapObservation
   observationOf(const madrona::math::Vector3 &position,

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -75,11 +75,13 @@ int main(int argc, char *argv[])
         .gpuID = 0,
         .numWorlds = num_worlds,
         .jsonPath = "tests/testJsons",
-        .params = {
-            .polylineReductionThreshold = 1.0,
-            .observationRadius = 100.0,
-            .maxNumControlledVehicles = 0
-        },
+        .params = {.polylineReductionThreshold = 1.0,
+                   .observationRadius = 100.0,
+                   .rewardParams = {.rewardType = RewardType::OnGoalAchieved,
+                                    .distanceToGoalThreshold = 0.5,
+                                    .distanceToExpertThreshold = 0.5},
+                   .datasetInitOptions = DatasetInitOptions::ExactN,
+		   .maxNumControlledVehicles = 0},
         .enableBatchRenderer = enable_batch_renderer,
         .extRenderAPI = wm.gpuAPIManager().backend(),
         .extRenderDev = render_gpu.device(),
@@ -153,7 +155,7 @@ int main(int argc, char *argv[])
     };
 
     viewer.loop(
-    [](CountT world_idx, const Viewer::UserInput &input) {
+    [](CountT world_idx, const Viewer::UserInput & /* input */) {
         (void)world_idx;
     },
     [&mgr](CountT world_idx, CountT agent_idx,
@@ -169,8 +171,6 @@ int main(int argc, char *argv[])
         if (input.keyPressed(Key::R)) {
             mgr.triggerReset(world_idx);
         }
-
-        bool shift_pressed = input.keyPressed(Key::Shift);
 
         if (input.keyPressed(Key::W)) {
             acceleration += accelerationDelta;

--- a/tests/bicyclemodel.cpp
+++ b/tests/bicyclemodel.cpp
@@ -30,9 +30,9 @@ protected:
             .useWayMaxModel = false
         }
     });
-    
-    uint32_t num_agents = gpudrive::consts::kMaxAgentCount;
-    int64_t num_roads = gpudrive::consts::kMaxRoadEntityCount;
+
+    CountT num_agents = gpudrive::consts::kMaxAgentCount;
+    CountT num_roads = gpudrive::consts::kMaxRoadEntityCount;
     int64_t num_steps = 10;
     int64_t num_worlds = 1;
     int64_t numEntities = 0;
@@ -102,7 +102,7 @@ std::tuple<float, float, float, float> StepBicycleModel(float x, float y, float 
 
 std::pair<bool, std::string> validateBicycleModel(const py::Tensor &abs_obs, const py::Tensor &self_obs, const std::vector<float> &expected, const uint32_t num_agents)
 {
-    int64_t num_elems = 1;
+    std::size_t num_elems = 1;
     for (int i = 0; i < abs_obs.numDims(); i++)
     {
         num_elems *= abs_obs.dims()[i];
@@ -126,8 +126,8 @@ std::pair<bool, std::string> validateBicycleModel(const py::Tensor &abs_obs, con
 
     float *ptr = static_cast<float *>(abs_obs.devicePtr());
 
-    for (int64_t i = 0, agent_idx = 0; i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;)
-    {
+    for (std::size_t i = 0, agent_idx = 0;
+         i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;) {
         auto x = static_cast<float>(ptr[i]);
         auto y = static_cast<float>(ptr[i + 1]);
         auto rot = static_cast<float>(ptr[i + 7]);
@@ -143,10 +143,10 @@ std::pair<bool, std::string> validateBicycleModel(const py::Tensor &abs_obs, con
             return {false, "Value mismatch."};
         }
     }
-    
+
     ptr = static_cast<float *>(self_obs.devicePtr());
-    for (int64_t i = 0, agent_idx = 0; i < num_agents * gpudrive::SelfObservationExportSize;)
-    {
+    for (std::size_t i = 0, agent_idx = 0;
+         i < num_agents * gpudrive::SelfObservationExportSize;) {
         auto speed = static_cast<float>(ptr[i]);
         auto speed_exp = expected[agent_idx+3];
 
@@ -167,8 +167,8 @@ std::vector<float> parseBicycleModel(const py::Tensor &abs_obs, const py::Tensor
     std::vector<float> obs;
     obs.resize(num_agents * 4);
     float *ptr = static_cast<float *>(abs_obs.devicePtr());
-    for (int i = 0, agent_idx = 0; i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;)
-    {
+    for (std::size_t i = 0, agent_idx = 0;
+         i < num_agents * gpudrive::AbsoluteSelfObservationExportSize;) {
         obs[agent_idx] = static_cast<float>(ptr[i]);
         obs[agent_idx+1] = static_cast<float>(ptr[i+1]);
         obs[agent_idx+2] = static_cast<float>(ptr[i+7]);
@@ -176,8 +176,8 @@ std::vector<float> parseBicycleModel(const py::Tensor &abs_obs, const py::Tensor
         i+=gpudrive::AbsoluteSelfObservationExportSize;
     }
     ptr = static_cast<float *>(self_obs.devicePtr());
-    for (int i = 0, agent_idx = 0; i < num_agents * gpudrive::SelfObservationExportSize;)
-    {
+    for (std::size_t i = 0, agent_idx = 0;
+         i < num_agents * gpudrive::SelfObservationExportSize;) {
         obs[agent_idx+3] = static_cast<float>(ptr[i]);
         agent_idx += 4;
         i+=gpudrive::SelfObservationExportSize;
@@ -239,5 +239,4 @@ TEST_F(BicycleKinematicModelTest, TestModelEvolution) {
         std::tie(valid, errorMsg) = validateBicycleModel(abs_obs, self_obs, expected, num_agents);
         ASSERT_TRUE(valid);
     }
-
 }


### PR DESCRIPTION
This PR addresses all compiler warnings under `/src`, and adds the `-Werror` compiler flag to cmake (which upgrades compiler warnings to compile errors) to stop future warnings from being introduced.

Note that there are about a dozen warnings originating from Madrona itself.