### PR TITLE
Split reset into stand-alone TaskGraph

### DIFF
--- a/baselines/ippo/config.py
+++ b/baselines/ippo/config.py
@@ -44,7 +44,7 @@ class ExperimentConfig:
     gae_lambda: float = 0.95
     clip_range: float = 0.2
     vf_coef: float = 0.5
-    n_steps: int = 92  # Has to be at least > episode_length = 91
+    n_steps: int = 91
     num_minibatches: int = 5  # Used to determine the minibatch size
     verbose: int = 0
     total_timesteps: int = 6e7

--- a/pygpudrive/env/env_jax.py
+++ b/pygpudrive/env/env_jax.py
@@ -54,9 +54,7 @@ class GPUDriveJaxEnv(GPUDriveGymEnv):
 
     def reset(self):
         """Reset the worlds and return the initial observations."""
-        for sim_idx in range(self.num_worlds):
-            self.sim.reset(sim_idx)
-        self.sim.step()  # We require one step to trigger the reset
+        self.sim.reset(list(range(self.num_worlds)))
         return self.get_obs()
 
     def get_dones(self):

--- a/pygpudrive/env/env_torch.py
+++ b/pygpudrive/env/env_torch.py
@@ -53,9 +53,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
     def reset(self):
         """Reset the worlds and return the initial observations."""
-        for sim_idx in range(self.num_worlds):
-            self.sim.reset(sim_idx)
-        self.sim.step()  # We require one step to trigger the reset
+        self.sim.reset(list(range(self.num_worlds)))
         return self.get_obs()
 
     def get_dones(self):

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -92,8 +92,7 @@ namespace gpudrive
                 nb::arg("batch_render_view_width") = 64,
                 nb::arg("batch_render_view_height") = 64)
             .def("step", &Manager::step)
-            .def("reset", &Manager::triggerReset)
-            .def("reset_tensor", &Manager::resetTensor)
+            .def("reset", &Manager::reset)
             .def("action_tensor", &Manager::actionTensor)
             .def("reward_tensor", &Manager::rewardTensor)
             .def("done_tensor", &Manager::doneTensor)

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -151,14 +151,9 @@ struct Manager::CPUImpl final : Manager::Impl {
         delete episodeMgr;
     }
 
-    inline virtual void step()
-    {
-        cpuExec.runTaskGraph(TaskGraphID::Step);
-    }
+    inline virtual void step() { cpuExec.runTaskGraph(TaskGraphID::Step); }
 
-    inline virtual void reset() {
-        cpuExec.runTaskGraph(TaskGraphID::Reset);
-    }
+    inline virtual void reset() { cpuExec.runTaskGraph(TaskGraphID::Reset); }
 
     virtual inline Tensor exportTensor(ExportID slot,
         TensorElementType type,
@@ -182,28 +177,23 @@ struct Manager::CUDAImpl final : Manager::Impl {
                    Action *action_buffer,
                    MWCudaExecutor &&gpu_exec,
                    Optional<RenderGPUState> &&render_gpu_state,
-		   Optional<render::RenderManager> &&render_mgr,
+                  Optional<render::RenderManager> &&render_mgr,
                    int64_t numWorlds)
         : Impl(mgr_cfg, std::move(phys_loader),
                ep_mgr, reset_buffer, action_buffer,
-               std::move(render_gpu_state), std::move(render_mgr), numWorlds),
+               std::move(render_gpu_state), std::move(render_mgr), numWorlds),  
           gpuExec(std::move(gpu_exec)),
           stepGraph(gpuExec.buildLaunchGraph(TaskGraphID::Step)),
-	  resetGraph(gpuExec.buildLaunchGraph(TaskGraphID::Reset)) {}
+          resetGraph(gpuExec.buildLaunchGraph(TaskGraphID::Reset)) {}
 
     inline virtual ~CUDAImpl() final
     {
         REQ_CUDA(cudaFree(episodeMgr));
     }
 
-    inline virtual void step()
-    {
-        gpuExec.run(stepGraph);
-    }
+    inline virtual void step() { gpuExec.run(stepGraph); }
 
-    inline virtual void reset() {
-        gpuExec.run(resetGraph);
-    }
+    inline virtual void reset() { gpuExec.run(resetGraph); }
 
     virtual inline Tensor exportTensor(ExportID slot,
         TensorElementType type,
@@ -574,9 +564,7 @@ Manager::Impl * Manager::Impl::init(const Manager::Config &mgr_cfg) {
     }
 }
 
-Manager::Manager(const Config &cfg) : impl_(Impl::init(cfg)) {
-    reset({});
-}
+Manager::Manager(const Config &cfg) : impl_(Impl::init(cfg)) { reset({}); }
 
 Manager::~Manager() {}
 
@@ -594,10 +582,10 @@ void Manager::step()
 }
 
 void Manager::reset(std::vector<int32_t> worldsToReset) {
-    for (const auto& worldIdx : worldsToReset) {
+    for (const auto &worldIdx : worldsToReset) {
         triggerReset(worldIdx);
     }
-    
+
     impl_->reset();
 
     if (impl_->renderMgr.has_value()) {

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -47,10 +47,10 @@ public:
     MGR_EXPORT ~Manager();
 
     MGR_EXPORT void step();
+    MGR_EXPORT void reset(std::vector<int32_t> worldsToReset);
 
     // These functions export Tensor objects that link the ECS
     // simulation state to the python bindings / PyTorch tensors (src/bindings.cpp)
-    MGR_EXPORT madrona::py::Tensor resetTensor() const;
     MGR_EXPORT madrona::py::Tensor actionTensor() const;
     MGR_EXPORT madrona::py::Tensor rewardTensor() const;
     MGR_EXPORT madrona::py::Tensor doneTensor() const;

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -116,7 +116,7 @@ inline void resetSystem(Engine &ctx, WorldReset &reset)
     }
 
     reset.reset = 0;
-  
+
     cleanupWorld(ctx);
     initWorld(ctx);
 }
@@ -446,7 +446,7 @@ inline void bonusRewardSystem(Engine &ctx,
     }
 }
 
-inline void stepTrackerSystem(Engine &ctx, StepsRemaining& stepsRemaining) {
+inline void stepTrackerSystem(Engine &ctx, StepsRemaining &stepsRemaining) {
     --stepsRemaining.t;
 }
 
@@ -454,11 +454,11 @@ inline void stepTrackerSystem(Engine &ctx, StepsRemaining& stepsRemaining) {
 // notify training that an episode has completed by
 // setting done = 1 on the final step of the episode
 inline void doneSystem(Engine &ctx,
-		       const Position &position,
-		       const Goal &goal,
-		       const StepsRemaining &steps_remaining,
-		       Done &done,
-		       Info &info)
+                      const Position &position,
+                      const Goal &goal,
+                      const StepsRemaining &steps_remaining,
+                      Done &done,
+                      Info &info)
 {
     int32_t num_remaining = steps_remaining.t;
     if (num_remaining == consts::episodeLen - 1 && done.v != 1)
@@ -644,16 +644,15 @@ inline void collectAbsoluteObservationsSystem(Engine &ctx,
     out.vehicle_size = vehicleSize;
 }
 
-void setupRestOfTasks(TaskGraphBuilder &builder,
-		      const Sim::Config &cfg,
-		      Span<const TaskGraphNodeID> dependencies, 
-		      bool decrementStep) {
+void setupRestOfTasks(TaskGraphBuilder &builder, const Sim::Config &cfg,
+                      Span<const TaskGraphNodeID> dependencies,
+                      bool decrementStep) {
     // setupBroadphaseTasks consists of the following sub-tasks:
     // 1. updateLeafPositionsEntry
     // 2. broadphase::updateBVHEntry
     // 3. broadphase::refitEntry
-    auto broadphase_setup_sys = phys::PhysicsSystem::setupBroadphaseTasks(
-        builder, dependencies);
+    auto broadphase_setup_sys =
+        phys::PhysicsSystem::setupBroadphaseTasks(builder, dependencies);
 
     auto findOverlappingEntities =
         phys::PhysicsSystem::setupStandaloneBroadphaseOverlapTasks(
@@ -681,12 +680,16 @@ void setupRestOfTasks(TaskGraphBuilder &builder,
 
     auto previousSystem = reward_sys;
     if (decrementStep) {
-      previousSystem = builder.addToGraph<ParallelForNode<Engine, stepTrackerSystem, StepsRemaining>>({reward_sys});
+        previousSystem = builder.addToGraph<
+            ParallelForNode<Engine, stepTrackerSystem, StepsRemaining>>(
+            {reward_sys});
     }
 
     // Check if the episode is over
-    auto done_sys = builder.addToGraph<
-      ParallelForNode<Engine, doneSystem, Position, Goal, StepsRemaining, Done, Info>>({previousSystem});
+    auto done_sys =
+        builder.addToGraph<ParallelForNode<Engine, doneSystem, Position, Goal,
+                                           StepsRemaining, Done, Info>>(
+            {previousSystem});
 
     auto clear_tmp = builder.addToGraph<ResetTmpAllocNode>({done_sys});
     (void)clear_tmp;
@@ -710,7 +713,7 @@ void setupRestOfTasks(TaskGraphBuilder &builder,
             Progress,
             OtherAgents,
             SelfObservation,
-	        PartnerObservations,
+            PartnerObservations,
             AgentMapObservations,
             EntityType,
             CollisionDetectionEvent
@@ -780,13 +783,15 @@ static void setupStepTasks(TaskGraphBuilder &builder, const Sim::Config &cfg) {
             CollisionDetectionEvent,
             ResponseType,
             Done
-        >>({});
+        >>({});  
 
     setupRestOfTasks(builder, cfg, {moveSystem}, true);
 }
 
 static void setupResetTasks(TaskGraphBuilder &builder, const Sim::Config &cfg) {
-    auto reset = builder.addToGraph<ParallelForNode<Engine, resetSystem,  WorldReset>>({});
+    auto reset =
+        builder.addToGraph<ParallelForNode<Engine, resetSystem, WorldReset>>(
+            {});
 
     setupRestOfTasks(builder, cfg, {reset}, false);
 }

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -57,8 +57,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerArchetype<PhysicsEntity>();
     registry.registerArchetype<CameraAgent>();
 
-    registry.exportSingleton<WorldReset>(
-        (uint32_t)ExportID::Reset);
+    registry.exportSingleton<WorldReset>((uint32_t)ExportID::Reset);
     registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
     registry.exportColumn<Agent, Action>(
         (uint32_t)ExportID::Action);
@@ -107,7 +106,7 @@ static inline void initWorld(Engine &ctx)
     generateWorld(ctx);
 }
 
-// This system runs each frame and checks if the code external to the
+// This system runs in TaskGraphID::Reset and checks if the code external to the
 // application has forced a reset by writing to the WorldReset singleton. If a
 // reset is needed, cleanup the existing world and generate a new one.
 inline void resetSystem(Engine &ctx, WorldReset &reset)
@@ -117,6 +116,7 @@ inline void resetSystem(Engine &ctx, WorldReset &reset)
     }
 
     reset.reset = 0;
+  
     cleanupWorld(ctx);
     initWorld(ctx);
 }
@@ -446,18 +446,21 @@ inline void bonusRewardSystem(Engine &ctx,
     }
 }
 
+inline void stepTrackerSystem(Engine &ctx, StepsRemaining& stepsRemaining) {
+    --stepsRemaining.t;
+}
+
 // Keep track of the number of steps remaining in the episode and
 // notify training that an episode has completed by
 // setting done = 1 on the final step of the episode
-inline void stepTrackerSystem(Engine &ctx,
-                              const Position &position,
-                              const Goal &goal,
-                              StepsRemaining &steps_remaining,
-                              Done &done,
-                              Info &info)
+inline void doneSystem(Engine &ctx,
+		       const Position &position,
+		       const Goal &goal,
+		       const StepsRemaining &steps_remaining,
+		       Done &done,
+		       Info &info)
 {
-    // Absolute done is 90 steps.
-    int32_t num_remaining = --steps_remaining.t;
+    int32_t num_remaining = steps_remaining.t;
     if (num_remaining == consts::episodeLen - 1 && done.v != 1)
     { // Make sure to not reset an agent's done flag
         done.v = 0;
@@ -641,34 +644,16 @@ inline void collectAbsoluteObservationsSystem(Engine &ctx,
     out.vehicle_size = vehicleSize;
 }
 
-// Build the task graph
-void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
-{
-    TaskGraphBuilder &builder = taskgraph_mgr.init(TaskGraphID::Step);
-
-    // Turn policy actions into movement
-    auto moveSystem = builder.addToGraph<ParallelForNode<Engine,
-        movementSystem,
-            Action,
-            VehicleSize,
-            Rotation,
-            Position,
-            Velocity,
-            ControlledState,
-            EntityType,
-            StepsRemaining,
-            Trajectory,
-            CollisionDetectionEvent,
-            ResponseType,
-            Done
-        >>({});
-
+void setupRestOfTasks(TaskGraphBuilder &builder,
+		      const Sim::Config &cfg,
+		      Span<const TaskGraphNodeID> dependencies, 
+		      bool decrementStep) {
     // setupBroadphaseTasks consists of the following sub-tasks:
     // 1. updateLeafPositionsEntry
     // 2. broadphase::updateBVHEntry
     // 3. broadphase::refitEntry
     auto broadphase_setup_sys = phys::PhysicsSystem::setupBroadphaseTasks(
-        builder, {moveSystem});
+        builder, dependencies);
 
     auto findOverlappingEntities =
         phys::PhysicsSystem::setupStandaloneBroadphaseOverlapTasks(
@@ -694,35 +679,25 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
             Reward
         >>({phys_done});
 
+    auto previousSystem = reward_sys;
+    if (decrementStep) {
+      previousSystem = builder.addToGraph<ParallelForNode<Engine, stepTrackerSystem, StepsRemaining>>({reward_sys});
+    }
 
     // Check if the episode is over
     auto done_sys = builder.addToGraph<
-        ParallelForNode<Engine, stepTrackerSystem, Position, Goal, StepsRemaining, Done, Info>>(
-        {reward_sys});
+      ParallelForNode<Engine, doneSystem, Position, Goal, StepsRemaining, Done, Info>>({previousSystem});
 
-    // Conditionally reset the world if the episode is over
-    auto reset_sys = builder.addToGraph<ParallelForNode<Engine,
-        resetSystem,
-            WorldReset
-        >>({done_sys});
-
-    auto clear_tmp = builder.addToGraph<ResetTmpAllocNode>({reset_sys});
+    auto clear_tmp = builder.addToGraph<ResetTmpAllocNode>({done_sys});
     (void)clear_tmp;
 
 
 #ifdef MADRONA_GPU_MODE
     // RecycleEntitiesNode is required on the GPU backend in order to reclaim
     // deleted entity IDs.
-    auto recycle_sys = builder.addToGraph<RecycleEntitiesNode>({reset_sys});
+    auto recycle_sys = builder.addToGraph<RecycleEntitiesNode>({done_sys});
     (void)recycle_sys;
 #endif
-
-    // This second BVH build is a limitation of the current taskgraph API.
-    // It's only necessary if the world was reset, but we don't have a way
-    // to conditionally queue taskgraph nodes yet.
-    auto post_reset_broadphase =
-        phys::PhysicsSystem::setupBroadphaseTasks(builder,
-                                                           {reset_sys});
 
     // Finally, collect observations for the next step.
     auto collect_obs = builder.addToGraph<ParallelForNode<Engine,
@@ -739,7 +714,7 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
             AgentMapObservations,
             EntityType,
             CollisionDetectionEvent
-        >>({post_reset_broadphase});
+        >>({clear_tmp});
 
     auto collectAbsoluteSelfObservations = builder.addToGraph<
         ParallelForNode<Engine, collectAbsoluteObservationsSystem, Position,
@@ -747,7 +722,7 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
         {collect_obs});
 
     if (cfg.renderBridge) {
-        RenderingSystem::setupTasks(builder, {reset_sys});
+        RenderingSystem::setupTasks(builder, {done_sys});
     }
 
     TaskGraphNodeID lidar;
@@ -788,6 +763,37 @@ void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg)
     (void)lidar;
     (void)collectAbsoluteSelfObservations;
 #endif
+}
+
+static void setupStepTasks(TaskGraphBuilder &builder, const Sim::Config &cfg) {
+    auto moveSystem = builder.addToGraph<ParallelForNode<Engine,
+        movementSystem,
+            Action,
+            VehicleSize,
+            Rotation,
+            Position,
+            Velocity,
+            ControlledState,
+            EntityType,
+            StepsRemaining,
+            Trajectory,
+            CollisionDetectionEvent,
+            ResponseType,
+            Done
+        >>({});
+
+    setupRestOfTasks(builder, cfg, {moveSystem}, true);
+}
+
+static void setupResetTasks(TaskGraphBuilder &builder, const Sim::Config &cfg) {
+    auto reset = builder.addToGraph<ParallelForNode<Engine, resetSystem,  WorldReset>>({});
+
+    setupRestOfTasks(builder, cfg, {reset}, false);
+}
+
+void Sim::setupTasks(TaskGraphManager &taskgraph_mgr, const Config &cfg) {
+    setupResetTasks(taskgraph_mgr.init(TaskGraphID::Reset), cfg);
+    setupStepTasks(taskgraph_mgr.init(TaskGraphID::Step), cfg);
 }
 
 Sim::Sim(Engine &ctx,

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -49,6 +49,7 @@ enum class SimObject : uint32_t {
 
 enum class TaskGraphID : uint32_t {
     Step,
+    Reset,
     NumTaskGraphs,
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -44,6 +44,7 @@ struct VehicleSize {
 struct Goal{
     madrona::math::Vector2 position;
 };
+
 // WorldReset is a per-world singleton component that causes the current
 // episode to be terminated and the world regenerated
 // (Singleton components like WorldReset can be accessed via Context::singleton
@@ -52,7 +53,6 @@ struct WorldReset {
     int32_t reset;
 };
 
-// TODO(samk): need to wrap elements in std::optional to match Nocturne?
 struct Action {
     float acceleration;
     float steering;


### PR DESCRIPTION
Previously, a single task-graph (with `TaskGraphID::Step`) was responsible for both reseting and stepping an environment. To reset an environment K, `gpudrive.SimManager.reset(K)` was invoked prior to the next invocation of step. In this way, reset was a lazy operation.

This PR introduces a new task-graph (with `TaskGraphID::Reset`) and moves reset functionality out of `TaskGraphID::Step` and into `TaskGraphID::Reset`.  The logical layout of these task-graphs is as follows:

`TaskGraphID::Step`: Agent Dynamics --> Rewards --> Update Step Counter --> Done --> Observations
`TaskGraphID::Reset`: Reset for specified worlds --> Rewards --> Done --> Observations

Note that the step counter is only updated in a reset.

Important things to note:

- `gpudrive.SimManager.reset(...)` is now bound to the reset task-graph itself so that reset is now an eager operation.
-  `n_steps` has been changed back to 91 (matching the simulator's internal state) because a reset no longer updates the step counter
- A BVH rebuild in `TaskGraphID::Step` has been removed, potentially improving ASPS