### PR TITLE
Zero initialize observations

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -182,10 +182,8 @@ inline void collectObservationsSystem(Engine &ctx,
             .type = (float)ctx.get<EntityType>(other)
         };
     }
-    while(arrIndex < consts::kMaxAgentCount - 1)
-    {
-        partner_obs.obs[arrIndex].type = (float)EntityType::None;
-        arrIndex++;
+    while(arrIndex < consts::kMaxAgentCount - 1) {
+        partner_obs.obs[arrIndex++] = PartnerObservation::zero();
     }
 
     const auto alg = ctx.data().params.roadObservationAlgorithm;
@@ -214,12 +212,8 @@ inline void collectObservationsSystem(Engine &ctx,
         arrIndex++;
     }
 
-    while (arrIndex < consts::kMaxAgentMapObservationsCount)
-    {
-        map_obs.obs[arrIndex].position = Vector2{0.f, 0.f};
-        map_obs.obs[arrIndex].heading = 0.f;
-        map_obs.obs[arrIndex].type = (float)EntityType::None;
-        arrIndex++;
+    while (arrIndex < consts::kMaxAgentMapObservationsCount) {
+        map_obs.obs[arrIndex++] = MapObservation::zero();
     }
 }
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -103,6 +103,15 @@ struct MapObservation {
     Scale scale;
     float heading;
     float type;
+
+    static inline MapObservation zero() {
+      return MapObservation {
+	.position = {0, 0},
+	.scale = madrona::math::Diag3x3{0, 0, 0},
+	.heading = 0,
+	.type = static_cast<float>(EntityType::None)
+      };
+    }
 };
 
 const size_t MapObservationExportSize = 7;
@@ -115,6 +124,16 @@ struct PartnerObservation {
     float heading;
     VehicleSize vehicle_size;
     float type;
+
+    static inline PartnerObservation zero() {
+      return PartnerObservation {
+	  .speed = 0,
+	  .position = {0, 0},
+	  .heading = 0,
+	  .vehicle_size = {0, 0},
+          .type = static_cast<float>(EntityType::None)
+      };
+    }
 };
 
 // Egocentric observations of other agents


### PR DESCRIPTION
On a GPU, it seems either Madrona or the CUDA runtime zero-initializes the memory backing `PartnerObservations` and `AgentMapObservations`. On a CPU, this memory is left uninitialized which manifests itself as some floats taking on a `nan` value.

This PR zero-initializes `PartnerObservation` and `AgentMapObservation` which are unfilled. Note that k-NN already zero-initializes unfilled features and so does not need updating.