### PR TITLE
Destroy simulator on closure

### DIFF
--- a/pygpudrive/env/base_env.py
+++ b/pygpudrive/env/base_env.py
@@ -110,8 +110,8 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
 
         params = self._set_collision_behavior(params)
         params = self._set_road_reduction_params(params)
-        
-        # Map entity types to integers  
+
+        # Map entity types to integers
         self.ENTITY_TYPE_TO_INT = {
             gpudrive.EntityType._None: 0,
             gpudrive.EntityType.RoadEdge: 1,
@@ -241,6 +241,10 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
             RenderMode.MADRONA_DEPTH,
         }:
             return self.visualizer.getRender()
+
+    def close(self):
+        """Destroy the simulator."""
+        del self.sim()
 
     def normalize_tensor(self, x, min_val, max_val):
         """Normalizes an array of values to the range [-1, 1].

--- a/pygpudrive/env/base_env.py
+++ b/pygpudrive/env/base_env.py
@@ -244,7 +244,7 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
 
     def close(self):
         """Destroy the simulator and visualizer."""
-        del self.sim()
+        del self.sim
         self.visualizer.destroy()
 
     def normalize_tensor(self, x, min_val, max_val):

--- a/pygpudrive/env/base_env.py
+++ b/pygpudrive/env/base_env.py
@@ -243,8 +243,9 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
             return self.visualizer.getRender()
 
     def close(self):
-        """Destroy the simulator."""
+        """Destroy the simulator and visualizer."""
         del self.sim()
+        self.visualizer.destroy()
 
     def normalize_tensor(self, x, min_val, max_val):
         """Normalizes an array of values to the range [-1, 1].

--- a/pygpudrive/env/env_jax.py
+++ b/pygpudrive/env/env_jax.py
@@ -341,6 +341,4 @@ if __name__ == "__main__":
 
     # import imageio
     # imageio.mimsave("world1.gif", frames_1)
-
-    # run.finish()
-    env.visualizer.destroy()
+    env.close()


### PR DESCRIPTION
Only changes made are related to `env.close()` (the rest is accidental linting)