### PR TITLE
Fix headless to support the new scene initialization method

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ To further test the setup, you can run the pytests in the root directory:
 pytest
 ```
 
-To test if the simulator compiled correctly (and python lib did not), try running the headless program from the build directory. Remember to change the location of the data in `src/headless.cpp` and compiling again before running it.
+To test if the simulator compiled correctly (and python lib did not), try running the headless program from the build directory.
 
 ```bash
 cd build
-./headless CPU 1 1 # Run on CPU , 1 world, 1 step
+./headless CPU 1 # Run on CPU, 1 step
 ```
 
 ## Dataset `{ 🚦 🚗  🚙  🛣️ }`

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -33,8 +33,11 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    uint64_t num_steps = std::stoul(argv[3]); 
-    uint64_t num_worlds = 16;
+    uint64_t num_steps = std::stoul(argv[2]);
+    std::vector<std::string> scenes = {"../data/tfrecord-00001-of-01000_307.json",
+         "../data/tfrecord-00003-of-01000_109.json",
+         "../data/tfrecord-00012-of-01000_389.json"};
+    uint64_t num_worlds = scenes.size();
 
     bool rand_actions = false;
     if (argc >= 4) {
@@ -46,7 +49,7 @@ int main(int argc, char *argv[])
     Manager mgr({
         .execMode = exec_mode,
         .gpuID = 0,
-        .scenes = {"../maps.16"},
+        .scenes = scenes,
         .params = {
             .polylineReductionThreshold = 1.0,
             .observationRadius = 100.0,
@@ -55,7 +58,7 @@ int main(int argc, char *argv[])
                 .distanceToGoalThreshold = 0.5,
                 .distanceToExpertThreshold = 0.5
             },
-            .maxNumControlledVehicles = 0,
+            .maxNumControlledVehicles = 2,
         }
     });
 
@@ -87,7 +90,6 @@ int main(int argc, char *argv[])
 
         // printf("Map Obs\n");
         // map_obs_printer.print();
-        // printf("\n");
 
         // printf("Shape\n");
         // shapePrinter.print();
@@ -109,7 +111,7 @@ int main(int argc, char *argv[])
     };
 
     auto worldToShape =
-	mgr.getShapeTensorFromDeviceMemory(exec_mode, num_worlds);
+	mgr.getShapeTensorFromDeviceMemory(exec_mode);
 
     const auto start = std::chrono::steady_clock::now();
     for (CountT i = 0; i < (CountT)num_steps; i++) {

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
                 .distanceToGoalThreshold = 0.5,
                 .distanceToExpertThreshold = 0.5
             },
-            .maxNumControlledVehicles = 2,
+            .maxNumControlledVehicles = 0,
         }
     });
 

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -803,8 +803,8 @@ void Manager::setAction(int32_t world_idx, int32_t agent_idx,
 }
 
 std::vector<Shape>
-Manager::getShapeTensorFromDeviceMemory(madrona::ExecMode mode,
-                                        uint32_t numWorlds) {
+Manager::getShapeTensorFromDeviceMemory(madrona::ExecMode mode) {
+    const uint32_t numWorlds = impl_->numWorlds;
     const auto &tensor = shapeTensor();
 
     const std::size_t floatsPerShape{2};

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -78,7 +78,7 @@ public:
 
     // TODO: remove parameters
     MGR_EXPORT std::vector<Shape>
-    getShapeTensorFromDeviceMemory(madrona::ExecMode mode, uint32_t numWorlds);
+    getShapeTensorFromDeviceMemory(madrona::ExecMode mode);
 
     madrona::render::RenderManager & getRenderManager();
 


### PR DESCRIPTION
Headless is currently broken in main. This PR adds in the example data scene so that anyone can run headless directly after a build. Changes - 

1. Add in the example data json files (hardcoded as didnt want to introduce complexity).
2. Remove num_worlds input param from the command line arguments as number of worlds is now inferred from the size of file list.
3. Fix the get shape method to not depend on num_world input parameter.