### PR TITLE
[WIP] Unify actions in a single struct

### DIFF
--- a/algorithms/il/data_generation.py
+++ b/algorithms/il/data_generation.py
@@ -11,11 +11,19 @@ from pygpudrive.env.env_torch import GPUDriveTorchEnv
 
 logging.getLogger(__name__)
 
+
 def parse_args():
-    parser = argparse.ArgumentParser('Select the dynamics model that you use')
-    parser.add_argument('--dynamics-model', '-d', type=str, default='delta_local', choices=['delta_local', 'bicycle', 'classic'],)
+    parser = argparse.ArgumentParser("Select the dynamics model that you use")
+    parser.add_argument(
+        "--dynamics-model",
+        "-d",
+        type=str,
+        default="delta_local",
+        choices=["delta_local", "bicycle", "classic"],
+    )
     args = parser.parse_args()
     return args
+
 
 def map_to_closest_discrete_value(grid, cont_actions):
     """
@@ -32,16 +40,16 @@ def map_to_closest_discrete_value(grid, cont_actions):
 
 
 def generate_state_action_pairs(
-        env,
-        device,
-        action_space_type='discrete',
-        use_action_indices=False,
-        make_video=False,
-        render_index=[0],
-        num_action=10000,
-        save_path="output_video.mp4",
-        debug_world_idx=None,
-        debug_veh_idx=None,
+    env,
+    device,
+    action_space_type="discrete",
+    use_action_indices=False,
+    make_video=False,
+    render_index=[0],
+    num_action=10000,
+    save_path="output_video.mp4",
+    debug_world_idx=None,
+    debug_veh_idx=None,
 ):
     """Generate pairs of states and actions from the Waymo Open Dataset.
 
@@ -68,27 +76,35 @@ def generate_state_action_pairs(
     obs = env.reset()
 
     # Get expert actions for full trajectory in all worlds
-    expert_actions, expert_speeds, expert_positions = env.get_expert_actions(debug_world_idx, debug_veh_idx)
+    expert_actions, expert_speeds, expert_positions = env.get_expert_actions(
+        debug_world_idx, debug_veh_idx
+    )
     raw_expert_action = expert_actions.clone()
 
     expert_dx, expert_dy, expert_dyaw = None, None, None
     expert_accel, expert_steer = None, None
     if debug_world_idx is not None and debug_veh_idx is not None:
-        if env.action_features == 'delta_local':
+        if env.config.dynamics_model == "delta_local":
             expert_dx = raw_expert_action[debug_world_idx, debug_veh_idx, :, 0]
             expert_dy = raw_expert_action[debug_world_idx, debug_veh_idx, :, 1]
-            expert_dyaw = raw_expert_action[debug_world_idx, debug_veh_idx, :, 2]
+            expert_dyaw = raw_expert_action[
+                debug_world_idx, debug_veh_idx, :, 2
+            ]
         else:
-            expert_accel = raw_expert_action[debug_world_idx, debug_veh_idx, :, 0]
-            expert_steer = raw_expert_action[debug_world_idx, debug_veh_idx, :, 1]
+            expert_accel = raw_expert_action[
+                debug_world_idx, debug_veh_idx, :, 0
+            ]
+            expert_steer = raw_expert_action[
+                debug_world_idx, debug_veh_idx, :, 1
+            ]
         # for (pos_x, pos_y), speed in zip(expert_positions, expert_speeds):
         #     print(f'position : ({pos_x}. {pos_y}), speed : {speed}')
-    if action_space_type == 'discrete':
+    if action_space_type == "discrete":
         logging.info("Discretizing expert actions... \n")
         # Discretize the expert actions: map every value to the closest
         # value in the action grid.
         disc_expert_actions = expert_actions.clone()
-        if env.action_features == 'delta_local':
+        if env.config.dynamics_model == "delta_local":
             disc_expert_actions[:, :, :, 0], _ = map_to_closest_discrete_value(
                 grid=env.dx, cont_actions=expert_actions[:, :, :, 0]
             )
@@ -123,11 +139,15 @@ def generate_state_action_pairs(
                         action_val_tuple = tuple(
                             round(x, 3)
                             for x in disc_expert_actions[
-                                     world_idx, agent_idx, time_idx, :
-                                     ].tolist()
+                                world_idx, agent_idx, time_idx, :
+                            ].tolist()
                         )
-                        if not env.action_features == 'delta_local':
-                            action_val_tuple = (action_val_tuple[0], action_val_tuple[1], 0.0)
+                        if not env.config.dynamics_model == "delta_local":
+                            action_val_tuple = (
+                                action_val_tuple[0],
+                                action_val_tuple[1],
+                                0.0,
+                            )
 
                         action_idx = env.values_to_action_key.get(
                             action_val_tuple
@@ -140,8 +160,8 @@ def generate_state_action_pairs(
         else:
             # Map action values to joint action index
             expert_actions = disc_expert_actions
-    elif action_space_type == 'multi_discrete':
-        '''will be update'''
+    elif action_space_type == "multi_discrete":
+        """will be update"""
         pass
     else:
         logging.info("Using continuous expert actions... \n")
@@ -172,8 +192,12 @@ def generate_state_action_pairs(
 
         if debug_world_idx is not None and debug_veh_idx is not None:
             if dones[debug_world_idx, debug_veh_idx] == 0:
-                speeds.append(next_obs[debug_world_idx, debug_veh_idx, 0].unsqueeze(-1))
-                poss.append(next_obs[debug_world_idx, debug_veh_idx, 3:5].unsqueeze(0))
+                speeds.append(
+                    next_obs[debug_world_idx, debug_veh_idx, 0].unsqueeze(-1)
+                )
+                poss.append(
+                    next_obs[debug_world_idx, debug_veh_idx, 3:5].unsqueeze(0)
+                )
 
         # Unpack and store (obs, action, next_obs, dones) pairs for controlled agents
         expert_observations_lst.append(obs[~dead_agent_mask, :])
@@ -202,108 +226,157 @@ def generate_state_action_pairs(
     goal_mask = is_goal != 0
     valid_collision_mask = collision_mask & alive_agent_mask
     valid_goal_mask = goal_mask & alive_agent_mask
-    collision_rate = valid_collision_mask.sum().float() / alive_agent_mask.sum().float()
+    collision_rate = (
+        valid_collision_mask.sum().float() / alive_agent_mask.sum().float()
+    )
     goal_rate = valid_goal_mask.sum().float() / alive_agent_mask.sum().float()
 
     # print(f'Action: dx {combi[0]} dy {combi[1]} dyaw {combi[2]} | Collision {collision_rate} Goal {goal_rate}')
 
     if debug_world_idx is not None:
         speeds = torch.cat(speeds)
-        print(f'Environment speeds {speeds}')
+        print(f"Environment speeds {speeds}")
         poss = torch.cat(poss, dim=0)
-        print(f'Environment poss {poss}')
+        print(f"Environment poss {poss}")
     if make_video:
         for render in range(render_index[0], render_index[1]):
-            imageio.mimwrite(f'{save_path}_world_{render}.mp4', np.array(frames[render]), fps=30)
+            imageio.mimwrite(
+                f"{save_path}_world_{render}.mp4",
+                np.array(frames[render]),
+                fps=30,
+            )
 
     flat_expert_obs = torch.cat(expert_observations_lst, dim=0)
     flat_expert_actions = torch.cat(expert_actions_lst, dim=0)
     flat_next_expert_obs = torch.cat(expert_next_obs_lst, dim=0)
     flat_expert_dones = torch.cat(expert_dones_lst, dim=0)
     if debug_world_idx is not None:
-        '''for plotting '''
-        if env.action_features == 'delta_local':
+        """for plotting"""
+        if env.config.dynamics_model == "delta_local":
             fig, axs = plt.subplots(2, 3, figsize=(8, 8))
         else:
             fig, axs = plt.subplots(2, 2, figsize=(8, 8))
         # Speed plot
-        axs[0, 0].plot(expert_speeds.numpy(), label='Expert Speeds', color='b')
-        axs[0, 0].plot(speeds.numpy(), label='Simulation Speeds', color='r')
-        axs[0, 0].set_title('Speeds Comparison')
-        axs[0, 0].set_xlabel('Time Step')
-        axs[0, 0].set_ylabel('Speed')
+        axs[0, 0].plot(expert_speeds.numpy(), label="Expert Speeds", color="b")
+        axs[0, 0].plot(speeds.numpy(), label="Simulation Speeds", color="r")
+        axs[0, 0].set_title("Speeds Comparison")
+        axs[0, 0].set_xlabel("Time Step")
+        axs[0, 0].set_ylabel("Speed")
         axs[0, 0].legend()
 
         # Position plot
-        axs[0, 1].plot(expert_positions[:, 1].numpy(), expert_positions[:, 0].numpy(), label='Expert Position',
-                       color='b',
-                       marker='o')
-        axs[0, 1].plot(poss[:, 0].numpy(), poss[:, 1].numpy(), label='Environment Position', color='r', marker='x')
-        axs[0, 1].set_title('Position Comparison with Order')
-        axs[0, 1].set_xlabel('X Position')
-        axs[0, 1].set_ylabel('Y Position')
+        axs[0, 1].plot(
+            expert_positions[:, 1].numpy(),
+            expert_positions[:, 0].numpy(),
+            label="Expert Position",
+            color="b",
+            marker="o",
+        )
+        axs[0, 1].plot(
+            poss[:, 0].numpy(),
+            poss[:, 1].numpy(),
+            label="Environment Position",
+            color="r",
+            marker="x",
+        )
+        axs[0, 1].set_title("Position Comparison with Order")
+        axs[0, 1].set_xlabel("X Position")
+        axs[0, 1].set_ylabel("Y Position")
         axs[0, 1].legend()
 
-        if env.action_features == 'delta_local':
+        if env.config.dynamics_model == "delta_local":
             # dx plot
-            axs[1, 0].plot(expert_dx.numpy(), label='Expert dx', color='b')
-            axs[1, 0].plot(disc_expert_actions[debug_world_idx, debug_veh_idx, :, 0].numpy(), label='Simulation dx',
-                           color='r')
-            axs[1, 0].set_title('dx Comparison')
-            axs[1, 0].set_xlabel('Time Step')
-            axs[1, 0].set_ylabel('dx')
+            axs[1, 0].plot(expert_dx.numpy(), label="Expert dx", color="b")
+            axs[1, 0].plot(
+                disc_expert_actions[
+                    debug_world_idx, debug_veh_idx, :, 0
+                ].numpy(),
+                label="Simulation dx",
+                color="r",
+            )
+            axs[1, 0].set_title("dx Comparison")
+            axs[1, 0].set_xlabel("Time Step")
+            axs[1, 0].set_ylabel("dx")
             axs[1, 0].legend()
 
             # dy plot
-            axs[1, 1].plot(expert_dy.numpy(), label='Expert dy', color='b')
-            axs[1, 1].plot(disc_expert_actions[debug_world_idx, debug_veh_idx, :, 1].numpy(), label='Simulation dy',
-                           color='r')
-            axs[1, 1].set_title('dy Comparison')
-            axs[1, 1].set_xlabel('Time Step')
-            axs[1, 1].set_ylabel('dy')
+            axs[1, 1].plot(expert_dy.numpy(), label="Expert dy", color="b")
+            axs[1, 1].plot(
+                disc_expert_actions[
+                    debug_world_idx, debug_veh_idx, :, 1
+                ].numpy(),
+                label="Simulation dy",
+                color="r",
+            )
+            axs[1, 1].set_title("dy Comparison")
+            axs[1, 1].set_xlabel("Time Step")
+            axs[1, 1].set_ylabel("dy")
             axs[1, 1].legend()
 
             # dyaw plot
-            axs[1, 2].plot(expert_dyaw.numpy(), label='Expert dyaw', color='b')
-            axs[1, 2].plot(disc_expert_actions[debug_world_idx, debug_veh_idx, :, 2].numpy(), label='Simulation dyaw',
-                           color='r')
-            axs[1, 2].set_title('dyaw Comparison')
-            axs[1, 2].set_xlabel('Time Step')
-            axs[1, 2].set_ylabel('dyaw')
+            axs[1, 2].plot(expert_dyaw.numpy(), label="Expert dyaw", color="b")
+            axs[1, 2].plot(
+                disc_expert_actions[
+                    debug_world_idx, debug_veh_idx, :, 2
+                ].numpy(),
+                label="Simulation dyaw",
+                color="r",
+            )
+            axs[1, 2].set_title("dyaw Comparison")
+            axs[1, 2].set_xlabel("Time Step")
+            axs[1, 2].set_ylabel("dyaw")
             axs[1, 2].legend()
         else:
             # Accels plot
-            axs[1, 0].plot(expert_accel.numpy(), label='Expert Accels', color='b')
-            axs[1, 0].plot(disc_expert_actions[debug_world_idx, debug_veh_idx, :, 0].numpy(), label='Simulation Accels',
-                           color='r')
-            axs[1, 0].set_title('Accels Comparison')
-            axs[1, 0].set_xlabel('Time Step')
-            axs[1, 0].set_ylabel('Accels')
+            axs[1, 0].plot(
+                expert_accel.numpy(), label="Expert Accels", color="b"
+            )
+            axs[1, 0].plot(
+                disc_expert_actions[
+                    debug_world_idx, debug_veh_idx, :, 0
+                ].numpy(),
+                label="Simulation Accels",
+                color="r",
+            )
+            axs[1, 0].set_title("Accels Comparison")
+            axs[1, 0].set_xlabel("Time Step")
+            axs[1, 0].set_ylabel("Accels")
             axs[1, 0].legend()
 
             # Steers plot
-            axs[1, 1].plot(expert_steer.numpy(), label='Expert Steers', color='b')
-            axs[1, 1].plot(disc_expert_actions[debug_world_idx, debug_veh_idx, :, 1].numpy(), label='Simulation Steers',
-                           color='r')
-            axs[1, 1].set_title('Steers Comparison')
-            axs[1, 1].set_xlabel('Time Step')
-            axs[1, 1].set_ylabel('Steers')
+            axs[1, 1].plot(
+                expert_steer.numpy(), label="Expert Steers", color="b"
+            )
+            axs[1, 1].plot(
+                disc_expert_actions[
+                    debug_world_idx, debug_veh_idx, :, 1
+                ].numpy(),
+                label="Simulation Steers",
+                color="r",
+            )
+            axs[1, 1].set_title("Steers Comparison")
+            axs[1, 1].set_xlabel("Time Step")
+            axs[1, 1].set_ylabel("Steers")
             axs[1, 1].legend()
 
         plt.tight_layout()
-        plt.savefig(f'Analysis_numAction{num_action}_W{debug_world_idx}_V{debug_veh_idx}.jpg', dpi=150)
+        plt.savefig(
+            f"Analysis_numAction{num_action}_W{debug_world_idx}_V{debug_veh_idx}.jpg",
+            dpi=150,
+        )
     return (
         flat_expert_obs,
         flat_expert_actions,
         flat_next_expert_obs,
         flat_expert_dones,
         goal_rate,
-        collision_rate
+        collision_rate,
     )
 
 
 if __name__ == "__main__":
     import argparse
+
     args = parse_args()
     torch.set_printoptions(precision=3, sci_mode=False)
     NUM_WORLDS = 10
@@ -320,9 +393,13 @@ if __name__ == "__main__":
     num_dy_values = reversed(range(100, 101, 1))
     num_dyaw_values = reversed(range(300, 301, 1))
 
-    combinations = itertools.product(num_dx_values, num_dy_values, num_dyaw_values)
+    combinations = itertools.product(
+        num_dx_values, num_dy_values, num_dyaw_values
+    )
     render_config = RenderConfig(draw_obj_idx=True)
-    scene_config = SceneConfig("/data/formatted_json_v2_no_tl_train/", NUM_WORLDS)
+    scene_config = SceneConfig(
+        "/data/formatted_json_v2_no_tl_train/", NUM_WORLDS
+    )
     for combi in combinations:
         num_dx, num_dy, num_dyaw = combi
         env_config = EnvConfig(
@@ -333,15 +410,9 @@ if __name__ == "__main__":
             accel_actions=torch.round(
                 torch.linspace(-6.0, 6.0, 7), decimals=3
             ),
-            dx=torch.round(
-                torch.linspace(-3.0, 3.0, num_dx), decimals=3
-            ),
-            dy=torch.round(
-                torch.linspace(-3.0, 3.0, num_dy), decimals=3
-            ),
-            dyaw=torch.round(
-                torch.linspace(-1.0, 1.0, num_dyaw), decimals=3
-            ),
+            dx=torch.round(torch.linspace(-3.0, 3.0, num_dx), decimals=3),
+            dy=torch.round(torch.linspace(-3.0, 3.0, num_dy), decimals=3),
+            dyaw=torch.round(torch.linspace(-1.0, 1.0, num_dyaw), decimals=3),
         )
 
         env = GPUDriveTorchEnv(
@@ -358,18 +429,18 @@ if __name__ == "__main__":
             next_expert_obs,
             expert_dones,
             goal_rate,
-            collision_rate
+            collision_rate,
         ) = generate_state_action_pairs(
             env=env,
             device="cpu",
-            action_space_type='discrete',  # Discretize the expert actions
+            action_space_type="discrete",  # Discretize the expert actions
             use_action_indices=True,  # Map action values to joint action index
             make_video=True,  # Record the trajectories as sanity check
-            render_index=[0, 0],  #start_idx, end_idx
+            render_index=[0, 0],  # start_idx, end_idx
             debug_world_idx=None,
             debug_veh_idx=None,
             save_path="use_discr_actions_fix",
-            num_action=combi
+            num_action=combi,
         )
         env.close()
         del env
@@ -381,16 +452,18 @@ if __name__ == "__main__":
         num_actions.append(num_action)
         goal_rates.append(goal_rate.cpu().numpy())
         collision_rates.append(collision_rate.cpu().numpy())
-        print(f'dx {num_dx} dy {num_dy} dyaw {num_dyaw} Collision rate {collision_rate} Goal RATE {goal_rate}')
+        print(
+            f"dx {num_dx} dy {num_dy} dyaw {num_dyaw} Collision rate {collision_rate} Goal RATE {goal_rate}"
+        )
         # Plot the results
     plt.figure(figsize=(10, 5))
-    plt.plot(num_actions, goal_rates, label='Goal Rate', marker='o')
-    plt.plot(num_actions, collision_rates, label='Collision Rate', marker='x')
-    plt.xlabel('Number of Actions')
-    plt.ylabel('Rate')
-    plt.title('Goal Rate and Collision Rate vs. Number of Actions')
+    plt.plot(num_actions, goal_rates, label="Goal Rate", marker="o")
+    plt.plot(num_actions, collision_rates, label="Collision Rate", marker="x")
+    plt.xlabel("Number of Actions")
+    plt.ylabel("Rate")
+    plt.title("Goal Rate and Collision Rate vs. Number of Actions")
     plt.legend()
-    plt.savefig('Trade-off.jpg',dpi=300)
+    plt.savefig("Trade-off.jpg", dpi=300)
     # Uncommment to save the expert actions and observations
     # torch.save(expert_actions, "expert_actions.pt")
     # torch.save(expert_obs, "expert_obs.pt")

--- a/pygpudrive/env/README.md
+++ b/pygpudrive/env/README.md
@@ -1,4 +1,4 @@
-# GPU Drive Multi-Agent Environments Documentation
+# GPU Drive Multi-Agent Environments
 
 This repository provides base environments for multi-agent reinforcement learning using `torch` and `jax` in to interface with the `gpudrive` simulator. It follows the `gymnasium` environment standards as closely as possible.
 
@@ -12,14 +12,13 @@ Configure the environment using the basic settings in `config`:
 config = EnvConfig()
 ```
 
-This `config` all environment parameters. This `config` contains all environment parameters. One important configuration is the dynamics model, which determines how a successor state is computed (e.g. position, yaw, velocity) of one or more objects given an action (e.g. steering and acceleration). 
+This `config` contains all environment parameters. One important configuration is the dynamics model, which determines how a successor state is computed (e.g. position, yaw, velocity) of one or more objects given an action (e.g. steering and acceleration).
 
 The following dynamics models are currently implemented:
-- Classic: A kinematic bicycle model uses the center of gravity as reference point with 2D action (acceleration, steering curvature). It was used for [Nocturne](https://arxiv.org/pdf/2206.09889).
-- InvertibleBicycleModel. A kinematically realistic model using a 2D action (acceleration, steering curvature).  (taken from [source](https://github.com/waymo-research/waymax/tree/main/waymax/dynamics))
 
-- DeltaLocal. A position-based model using a 3D action (dx, dy, dyaw) representing the displacement of an object relative to the current position and orientation. This model does not check for infeasible actions, and large displacements may lead to unrealistic behavior. (taken from [source](https://github.com/waymo-research/waymax/tree/main/waymax/dynamics))
-
+- `Classic`: A kinematic bicycle model uses the center of gravity as reference point with 2D action (acceleration, steering curvature). It was used for [Nocturne](https://arxiv.org/pdf/2206.09889).
+- `InvertibleBicycleModel`. A kinematically realistic model using a 2D action (acceleration, steering curvature).  (taken from [source](https://github.com/waymo-research/waymax/tree/main/waymax/dynamics))
+- `DeltaLocal`. A position-based model using a 3D action (dx, dy, dyaw) representing the displacement of an object relative to the current position and orientation. This model does not check for infeasible actions, and large displacements may lead to unrealistic behavior. (taken from [source](https://github.com/waymo-research/waymax/tree/main/waymax/dynamics))
 
 For example, this creates an environment with one world and a maximum of three controllable agents per scenario:
 

--- a/pygpudrive/env/base_env.py
+++ b/pygpudrive/env/base_env.py
@@ -6,6 +6,7 @@ from pygpudrive.env.scene_selector import select_scenes
 import abc
 import gpudrive
 
+
 class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
     """Base class for multi-agent environments in GPUDrive.
 
@@ -18,12 +19,12 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def reset(self):
         """Reset the dynamics to inital state.
-    Args:
-        scenario: Scenario used to generate the initial state.
-        rng: Optional random number generator for stochastic environments.
+        Args:
+            scenario: Scenario used to generate the initial state.
+            rng: Optional random number generator for stochastic environments.
 
-        Returns:
-            The initial observations.
+            Returns:
+                The initial observations.
         """
 
     @abc.abstractmethod
@@ -92,10 +93,11 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
         Returns:
             object: Configured parameters for the simulation.
         """
-        self.dynamics_model = dict(
-            classic = gpudrive.DynamicsModel.Classic,
-            delta_local = gpudrive.DynamicsModel.DeltaLocal,
-            bicycle = gpudrive.DynamicsModel.InvertibleBicycle,
+        # Dict with supported dynamics models
+        self.dynamics_model_dict = dict(
+            classic=gpudrive.DynamicsModel.Classic,
+            delta_local=gpudrive.DynamicsModel.DeltaLocal,
+            bicycle=gpudrive.DynamicsModel.InvertibleBicycle,
         )
 
         params = gpudrive.Parameters()
@@ -106,12 +108,13 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
         params.IgnoreNonVehicles = self.config.remove_non_vehicles
         params.maxNumControlledVehicles = self.max_cont_agents
         params.isStaticAgentControlled = False
-        params.dynamicsModel = self.dynamics_model[self.config.dynamics_model]
+        params.dynamicsModel = self.dynamics_model_dict[
+            self.config.dynamics_model
+        ]
 
         if self.config.enable_lidar:
             params.enableLidar = self.config.enable_lidar
             params.disableClassicalObs = True
-
         params = self._set_collision_behavior(params)
         params = self._set_road_reduction_params(params)
 
@@ -131,8 +134,8 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
         }
         self.MIN_OBJ_ENTITY_ENUM = min(list(self.ENTITY_TYPE_TO_INT.values()))
         self.MAX_OBJ_ENTITY_ENUM = max(list(self.ENTITY_TYPE_TO_INT.values()))
-        self.ROAD_MAP_OBJECT_TYPES = 7 # (enums 0-6)
-        self.ROAD_OBJECT_TYPES = 4 # (enums 7-10)
+        self.ROAD_MAP_OBJECT_TYPES = 7  # (enums 0-6)
+        self.ROAD_OBJECT_TYPES = 4  # (enums 7-10)
 
         return params
 

--- a/pygpudrive/env/config.py
+++ b/pygpudrive/env/config.py
@@ -8,12 +8,13 @@ import torch
 import gpudrive
 from pygpudrive.env import constants
 
+
 @dataclass
 class EnvConfig:
     """Configuration settings for the GPUDrive gym environment.
 
     This class contains both Python-specific configurations and settings that
-    are shared between Python and C++ components of the simulator. 
+    are shared between Python and C++ components of the simulator.
 
     To modify simulator settings shared with C++, follow these steps:
     1. Navigate to `src/consts.hpp` in the C++ codebase.
@@ -33,32 +34,62 @@ class EnvConfig:
     # Road observation algorithm settings
     road_obs_algorithm: str = "linear"  # Algorithm for road observations
     obs_radius: float = 100.0  # Radius for road observations
-    polyline_reduction_threshold: float = 1.0  # Threshold for polyline reduction
+    polyline_reduction_threshold: float = (
+        1.0  # Threshold for polyline reduction
+    )
+
+    # Dynamics model
+    dynamics_model: str = (
+        "classic"  # Options: "classic", "bicycle", "delta_local"
+    )
+
     # Action space settings (joint discrete)
-    steer_actions: torch.Tensor = torch.round(torch.linspace(-1.0, 1.0, 13), decimals=3)
-    accel_actions: torch.Tensor = torch.round(torch.linspace(-4.0, 4.0, 7), decimals=3)
+    steer_actions: torch.Tensor = torch.round(
+        torch.linspace(-1.0, 1.0, 13), decimals=3
+    )
+    accel_actions: torch.Tensor = torch.round(
+        torch.linspace(-4.0, 4.0, 7), decimals=3
+    )
     dx: torch.Tensor = torch.round(torch.linspace(-2.0, 2.0, 20), decimals=3)
     dy: torch.Tensor = torch.round(torch.linspace(-2.0, 2.0, 20), decimals=3)
-    dyaw: torch.Tensor = torch.round(torch.linspace(-3.14, 3.14, 20), decimals=3)
-    dynamics_model: str = "classic" # Options: "classic", "bicycle", "delta_local"
+    dyaw: torch.Tensor = torch.round(
+        torch.linspace(-3.14, 3.14, 20), decimals=3
+    )
+
     # Collision behavior settings
     collision_behavior: str = "remove"  # Options: "remove", "stop", "ignore"
 
     # Scene configuration
-    remove_non_vehicles: bool = True  # Remove non-vehicle entities from the scene
+    remove_non_vehicles: bool = (
+        True  # Remove non-vehicle entities from the scene
+    )
 
     # Reward settings
-    reward_type: str = "sparse_on_goal_achieved"  # Options: "sparse_on_goal_achieved"
-    dist_to_goal_threshold: float = 3.0  # Radius around goal considered as "goal achieved"
+    reward_type: str = (
+        "sparse_on_goal_achieved"  # Options: "sparse_on_goal_achieved"
+    )
+    dist_to_goal_threshold: float = (
+        3.0  # Radius around goal considered as "goal achieved"
+    )
 
     # C++ and Python shared settings (modifiable via C++ codebase)
-    max_num_agents_in_scene: int = gpudrive.kMaxAgentCount  # Max number of objects in simulation
-    max_num_rg_points: int = gpudrive.kMaxRoadEntityCount  # Max number of road graph segments
-    roadgraph_top_k: int = gpudrive.kMaxAgentMapObservationsCount  # Top-K road graph segments agents can view
-    episode_len: int = gpudrive.episodeLen  # Length of an episode in the simulator
+    max_num_agents_in_scene: int = (
+        gpudrive.kMaxAgentCount
+    )  # Max number of objects in simulation
+    max_num_rg_points: int = (
+        gpudrive.kMaxRoadEntityCount
+    )  # Max number of road graph segments
+    roadgraph_top_k: int = (
+        gpudrive.kMaxAgentMapObservationsCount
+    )  # Top-K road graph segments agents can view
+    episode_len: int = (
+        gpudrive.episodeLen
+    )  # Length of an episode in the simulator
+
 
 class SelectionDiscipline(Enum):
     """Enum for selecting scenes discipline in dataset configuration."""
+
     FIRST_N = 0
     RANDOM_N = 1
     PAD_N = 2
@@ -76,6 +107,7 @@ class SceneConfig:
         discipline (SelectionDiscipline): Method for selecting scenes.
         k_unique_scenes (Optional[int]): Number of unique scenes if using K_UNIQUE_N discipline.
     """
+
     path: str
     num_scenes: int
     discipline: SelectionDiscipline = SelectionDiscipline.PAD_N
@@ -84,6 +116,7 @@ class SceneConfig:
 
 class RenderMode(Enum):
     """Enum for specifying rendering mode."""
+
     PYGAME_ABSOLUTE = "pygame_absolute"
     PYGAME_EGOCENTRIC = "pygame_egocentric"
     PYGAME_LIDAR = "pygame_lidar"
@@ -93,12 +126,14 @@ class RenderMode(Enum):
 
 class PygameOption(Enum):
     """Enum for Pygame rendering options."""
+
     HUMAN = "human"
     RGB = "rgb"
 
 
 class MadronaOption(Enum):
     """Enum for Madrona rendering options."""
+
     AGENT_VIEW = "agent_view"
     TOP_DOWN = "top_down"
 
@@ -116,6 +151,7 @@ class RenderConfig:
         obj_idx_font_size (int): Font size for object indices.
         color_scheme (str): Color scheme for the rendering ("light" or "dark").
     """
+
     render_mode: RenderMode = RenderMode.PYGAME_ABSOLUTE
     view_option: Enum = PygameOption.RGB
     resolution: Tuple[int, int] = (1024, 1024)
@@ -126,7 +162,9 @@ class RenderConfig:
 
     def __str__(self) -> str:
         """Returns a string representation of the rendering configuration."""
-        return (f"RenderMode: {self.render_mode.value}, ViewOption: {self.view_option.value}, "
-                f"Resolution: {self.resolution}, LineThickness: {self.line_thickness}, "
-                f"DrawObjectIdx: {self.draw_obj_idx}, ObjectIdxFontSize: {self.obj_idx_font_size}, "
-                f"ColorScheme: {self.color_scheme}")
+        return (
+            f"RenderMode: {self.render_mode.value}, ViewOption: {self.view_option.value}, "
+            f"Resolution: {self.resolution}, LineThickness: {self.line_thickness}, "
+            f"DrawObjectIdx: {self.draw_obj_idx}, ObjectIdxFontSize: {self.obj_idx_font_size}, "
+            f"ColorScheme: {self.color_scheme}"
+        )

--- a/pygpudrive/env/env_torch.py
+++ b/pygpudrive/env/env_torch.py
@@ -112,10 +112,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
             self.sim.action_tensor().to_torch()[:, :, :3].copy_(actions)
         elif self.config.dynamics_model == "delta_local":
             # Action space: (dx, dy, dyaw)
-            self.sim.action_tensor().to_torch()[:, :, 3:6].copy_(actions)
-            # Action space: (pos, yaw, velocity)
-        elif self.config.dynamics_model == "bicycle":
-            self.sim.action_tensor().to_torch()[:, :, 6:].copy_(actions)
+            self.sim.action_tensor().to_torch()[:, :, :3].copy_(actions)
         else:
             raise ValueError(
                 f"Invalid dynamics model: {self.config.dynamics_model}"

--- a/pygpudrive/env/env_torch.py
+++ b/pygpudrive/env/env_torch.py
@@ -34,11 +34,6 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
         # Environment parameter setup
         params = self._setup_environment_parameters()
-        params.dynamicsModel = self.dynamics_model[config.dynamics_model]
-        if config.dynamics_model == 'delta_local':
-            self.action_features = "delta_local"
-        else:
-            self.action_features = "bicycle"
 
         # Initialize simulator with parameters
         self.sim = self._initialize_simulator(params, scene_config)
@@ -104,32 +99,48 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         else:
             raise ValueError(f"Invalid action shape: {actions.shape}")
 
-        # Feed the actual action values to gpudrive
-        if self.action_features == 'delta_local':
-            self.sim.delta_action_tensor().to_torch().copy_(action_value_tensor)
+        # Feed the action values to gpudrive
+        self._copy_actions_to_simulator(action_value_tensor)
+
+    def _copy_actions_to_simulator(self, actions):
+        """Copy the provived actions to the simulator."""
+        if (
+            self.config.dynamics_model == "classic"
+            or self.config.dynamics_model == "bicycle"
+        ):
+            # Action space: (acceleration, steering, heading)
+            self.sim.action_tensor().to_torch()[:, :, :3].copy_(actions)
+        elif self.config.dynamics_model == "delta_local":
+            # Action space: (dx, dy, dyaw)
+            self.sim.action_tensor().to_torch()[:, :, 3:6].copy_(actions)
         else:
-            self.sim.action_tensor().to_torch().copy_(action_value_tensor)
+            raise ValueError(
+                f"Invalid dynamics model: {self.config.dynamics_model}"
+            )
 
     def _set_discrete_action_space(self) -> None:
-        """Configure the discrete action space."""
-        if self.action_features == 'delta_local':
+        """Configure the discrete action space based on dynamics model."""
+        if self.config.dynamics_model == "delta_local":
             self.dx = self.config.dx.to(self.device)
             self.dy = self.config.dy.to(self.device)
             self.dyaw = self.config.dyaw.to(self.device)
             products = product(self.dx, self.dy, self.dyaw)
-        else:
+        elif (
+            self.config.dynamics_model == "classic"
+            or self.config.dynamics_model == "bicycle"
+        ):
             self.steer_actions = self.config.steer_actions.to(self.device)
             self.accel_actions = self.config.accel_actions.to(self.device)
             self.head_actions = torch.tensor([0], device=self.device)
-            products = product(self.accel_actions, self.steer_actions, self.head_actions)
+            products = product(
+                self.accel_actions, self.steer_actions, self.head_actions
+            )
 
         # Create a mapping from action indices to action values
         self.action_key_to_values = {}
         self.values_to_action_key = {}
 
-        for action_idx, (action_1, action_2, action_3) in enumerate(
-            products
-        ):
+        for action_idx, (action_1, action_2, action_3) in enumerate(products):
             self.action_key_to_values[action_idx] = [
                 action_1.item(),
                 action_2.item(),
@@ -216,8 +227,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         return obs_filtered
 
     def get_controlled_agents_mask(self):
-        """Get the control mask. Bicycle = 1, DeltaModel = 2"""
-        # target_idx = 2 if self.action_features == 'delta' else 1
+        """Get the control mask."""
         return (self.sim.controlled_state_tensor().to_torch() == 1).squeeze(
             axis=2
         )
@@ -252,31 +262,43 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
     def get_expert_actions(self, debug_world_idx=None, debug_veh_idx=None):
         """Get expert actions for the full trajectories across worlds."""
         expert_traj = self.sim.expert_trajectory_tensor().to_torch()
-        positions = expert_traj[:, :, :2 * self.episode_len].view(self.num_worlds,
-                                                                  self.max_agent_count,
-                                                                  self.episode_len, -1)
+        positions = expert_traj[:, :, : 2 * self.episode_len].view(
+            self.num_worlds, self.max_agent_count, self.episode_len, -1
+        )
 
-        velocity = expert_traj[:, :, 2 * self.episode_len:4 * self.episode_len].view(self.num_worlds,
-                                                                                     self.max_agent_count,
-                                                                                     self.episode_len, -1)
-        if self.action_features == 'delta_local':
-            inferred_expert_actions = expert_traj[:, :, -3 * self.episode_len:].view(self.num_worlds,
-                                                                                     self.max_agent_count,
-                                                                                     self.episode_len, -1)
-            inferred_expert_actions[..., 0] = torch.clamp(inferred_expert_actions[..., 0], -6, 6)
-            inferred_expert_actions[..., 1] = torch.clamp(inferred_expert_actions[..., 1], -6, 6)
-            inferred_expert_actions[..., 2] = torch.clamp(inferred_expert_actions[..., 2], -3.14, 3.14)
+        velocity = expert_traj[
+            :, :, 2 * self.episode_len : 4 * self.episode_len
+        ].view(self.num_worlds, self.max_agent_count, self.episode_len, -1)
+        if self.config.dynamics_model == "delta_local":
+            inferred_expert_actions = expert_traj[
+                :, :, -3 * self.episode_len :
+            ].view(self.num_worlds, self.max_agent_count, self.episode_len, -1)
+            inferred_expert_actions[..., 0] = torch.clamp(
+                inferred_expert_actions[..., 0], -6, 6
+            )
+            inferred_expert_actions[..., 1] = torch.clamp(
+                inferred_expert_actions[..., 1], -6, 6
+            )
+            inferred_expert_actions[..., 2] = torch.clamp(
+                inferred_expert_actions[..., 2], -3.14, 3.14
+            )
         else:
-            inferred_expert_actions = expert_traj[:, :, -6 * self.episode_len:-3 * self.episode_len].view(
-                self.num_worlds,
-                self.max_agent_count,
-                self.episode_len, -1)
-            inferred_expert_actions[..., 0] = torch.clamp(inferred_expert_actions[..., 0], -6, 6)
-            inferred_expert_actions[..., 1] = torch.clamp(inferred_expert_actions[..., 1], -0.3, 0.3)
+            inferred_expert_actions = expert_traj[
+                :, :, -6 * self.episode_len : -3 * self.episode_len
+            ].view(self.num_worlds, self.max_agent_count, self.episode_len, -1)
+            inferred_expert_actions[..., 0] = torch.clamp(
+                inferred_expert_actions[..., 0], -6, 6
+            )
+            inferred_expert_actions[..., 1] = torch.clamp(
+                inferred_expert_actions[..., 1], -0.3, 0.3
+            )
         velo2speed = None
         debug_positions = None
         if debug_world_idx is not None and debug_veh_idx is not None:
-            velo2speed = torch.norm(velocity[debug_world_idx, debug_veh_idx], dim=-1) / self.config.max_speed
+            velo2speed = (
+                torch.norm(velocity[debug_world_idx, debug_veh_idx], dim=-1)
+                / self.config.max_speed
+            )
             positions[..., 0] = self.normalize_tensor(
                 positions[..., 0],
                 self.config.min_rel_goal_coord,
@@ -318,7 +340,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         obs[:, :, :, 3] /= constants.MAX_ORIENTATION_RAD
 
         # Vehicle length and width
-        obs[:, :, :, 4] /= constants.MAX_VEH_LEN    
+        obs[:, :, :, 4] /= constants.MAX_VEH_LEN
         obs[:, :, :, 5] /= constants.MAX_VEH_WIDTH
 
         # One-hot encode the type of the other visible objects
@@ -422,7 +444,7 @@ if __name__ == "__main__":
 
     env_config = EnvConfig()
     render_config = RenderConfig()
-    scene_config = SceneConfig("data", NUM_WORLDS)
+    scene_config = SceneConfig("data/examples", NUM_WORLDS)
 
     # MAKE ENV
     env = GPUDriveTorchEnv(
@@ -443,13 +465,15 @@ if __name__ == "__main__":
             [
                 [
                     env.action_space.sample()
-                    for _ in range(env_config.max_num_agents_in_scene * NUM_WORLDS)
+                    for _ in range(
+                        env_config.max_num_agents_in_scene * NUM_WORLDS
+                    )
                 ]
             ]
         ).reshape(NUM_WORLDS, env_config.max_num_agents_in_scene)
 
         # Step the environment
-        env.step_dynamics(None)
+        env.step_dynamics(rand_action)
 
         frames.append(env.render())
 

--- a/pygpudrive/env/env_torch.py
+++ b/pygpudrive/env/env_torch.py
@@ -113,6 +113,9 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         elif self.config.dynamics_model == "delta_local":
             # Action space: (dx, dy, dyaw)
             self.sim.action_tensor().to_torch()[:, :, 3:6].copy_(actions)
+            # Action space: (pos, yaw, velocity)
+        elif self.config.dynamics_model == "bicycle":
+            self.sim.action_tensor().to_torch()[:, :, 6:].copy_(actions)
         else:
             raise ValueError(
                 f"Invalid dynamics model: {self.config.dynamics_model}"

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -106,7 +106,6 @@ namespace gpudrive
             .def("step", &Manager::step)
             .def("reset", &Manager::reset)
             .def("action_tensor", &Manager::actionTensor)
-            .def("delta_action_tensor", &Manager::dActionTensor)
             .def("reward_tensor", &Manager::rewardTensor)
             .def("done_tensor", &Manager::doneTensor)
             .def("self_observation_tensor", &Manager::selfObservationTensor)

--- a/src/dynamics.hpp
+++ b/src/dynamics.hpp
@@ -148,21 +148,21 @@ namespace gpudrive
 
     }
 
-    inline DeltaAction inverseDeltaModel(const Rotation &rotation, const Position &position, const Rotation &targetRotation, const Position &targetPosition)
+    inline Action inverseDeltaModel(const Rotation &rotation, const Position &position, const Rotation &targetRotation, const Position &targetPosition)
     {
         const float dt{0.1};
 
-        DeltaAction action = {0, 0, 0};
+        Action action{.delta = {0, 0, 0}};
         float yaw = utils::quatToYaw(rotation);
         float target_yaw = utils::quatToYaw(targetRotation);
         // start delta model
             // start DeltaGlobal
-        action.dx = targetPosition.x - position.x;
-        action.dy = targetPosition.y - position.y;
-        action.dyaw = target_yaw - yaw;
+        action.delta.dx = targetPosition.x - position.x;
+        action.delta.dy = targetPosition.y - position.y;
+        action.delta.dyaw = target_yaw - yaw;
 
-        action.dx  = fmaxf(-6.0, fminf(action.dx, 6.0));
-        action.dy = fmaxf(-6.0, fminf(action.dy, 6.0));
+        action.delta.dx  = fmaxf(-6.0, fminf(action.delta.dx, 6.0));
+        action.delta.dy = fmaxf(-6.0, fminf(action.delta.dy, 6.0));
             // end DeltaGlobal
             // start DeltaLocal
 
@@ -172,12 +172,12 @@ namespace gpudrive
         float sin = std::sin(-yaw);
         // x = c * x - s * y
         // y = s * x + c * y
-        float local_dx= action.dx * cos - action.dy * sin;
-        float local_dy = action.dx * sin + action.dy * cos;
+        float local_dx= action.delta.dx * cos - action.delta.dy * sin;
+        float local_dy = action.delta.dx * sin + action.delta.dy * cos;
 
-        action.dx = fmaxf(-6.0, fminf(local_dx, 6.0));
-        action.dy = fmaxf(-6.0, fminf(local_dy, 6.0));
-        action.dyaw = fmaxf(-3.14, fminf(action.dyaw, 3.14));
+        action.delta.dx = fmaxf(-6.0, fminf(local_dx, 6.0));
+        action.delta.dy = fmaxf(-6.0, fminf(local_dy, 6.0));
+        action.delta.dyaw = fmaxf(-3.14, fminf(action.delta.dyaw, 3.14));
             // end DeltaLocal
         // end delta model
 

--- a/src/dynamics.hpp
+++ b/src/dynamics.hpp
@@ -26,8 +26,8 @@ namespace gpudrive
         float speed = velocity.linear.length();
         float yaw = utils::quatToYaw(rotation);
         // Average speed
-        const float v{clipSpeed(speed + 0.5f * action.acceleration * dt)};
-        const float tanDelta{tanf(action.steering)};
+        const float v{clipSpeed(speed + 0.5f * action.classic.acceleration * dt)};
+        const float tanDelta{tanf(action.classic.steering)};
         // Assume center of mass lies at the middle of length, then l / L == 0.5.
         const float beta{std::atan(0.5f * tanDelta)};
         const math::Vector2 d{polarToVector2D(v, yaw + beta)};
@@ -37,7 +37,7 @@ namespace gpudrive
         // model.heading = utils::AngleAdd(model.heading, w * dt);
         // model.speed = clipSpeed(model.speed + action.acceleration * dt);
         float new_yaw = utils::AngleAdd(yaw, w * dt);
-        float new_speed = clipSpeed(speed + action.acceleration * dt);
+        float new_speed = clipSpeed(speed + action.classic.acceleration * dt);
         position.x += d.x * dt;
         position.y += d.y * dt;
         position.z = 1;
@@ -52,22 +52,22 @@ namespace gpudrive
     inline void forwardBicycleModel(Action &action, Rotation &rotation, Position &position, Velocity &velocity)
     {
         // Clip acceleration and steering
-        action.acceleration = fmaxf(-6.0, fminf(action.acceleration, 6.0));
-        action.steering = fmaxf(-3.0, fminf(action.steering, 3.0));
+        action.classic.acceleration = fmaxf(-6.0, fminf(action.classic.acceleration, 6.0));
+        action.classic.steering = fmaxf(-3.0, fminf(action.classic.steering, 3.0));
 
         const float dt{0.1};
         float yaw = utils::quatToYaw(rotation);
         float speed = velocity.linear.length();
         //new_x = x + vel_x * t + 0.5 * accel * jnp.cos(yaw) * t**2
-        position.x = position.x + velocity.linear.x * dt + 0.5 * action.acceleration * cosf(yaw) * dt * dt;
+        position.x = position.x + velocity.linear.x * dt + 0.5 * action.classic.acceleration * cosf(yaw) * dt * dt;
         // new_y = y + vel_y * t + 0.5 * accel * jnp.sin(yaw) * t**2
-        position.y = position.y + velocity.linear.y * dt + 0.5 * action.acceleration * sinf(yaw) * dt * dt;
+        position.y = position.y + velocity.linear.y * dt + 0.5 * action.classic.acceleration * sinf(yaw) * dt * dt;
         // delta_yaw = steering * (speed * t + 0.5 * accel * t**2)
-        float delta_yaw = action.steering * (speed * dt + 0.5 * action.acceleration * dt * dt);
+        float delta_yaw = action.classic.steering * (speed * dt + 0.5 * action.classic.acceleration * dt * dt);
         // new_yaw = geometry.wrap_yaws(yaw + delta_yaw)
         float new_yaw = utils::AngleAdd(yaw, delta_yaw);
         // new_vel = speed + accel * t
-        float new_speed = speed + action.acceleration * dt;
+        float new_speed = speed + action.classic.acceleration * dt;
         // new_vel_x = new_vel * jnp.cos(new_yaw)
         velocity.linear.x = new_speed * cosf(new_yaw);
         // new_vel_y = new_vel * jnp.sin(new_yaw)
@@ -80,7 +80,7 @@ namespace gpudrive
         rotation = Quat::angleAxis(new_yaw, madrona::math::up);
     }
 
-    inline void forwardDeltaModel(DeltaAction &action, Rotation &rotation, Position &position, Velocity &velocity)
+    inline void forwardDeltaModel(Action &action, Rotation &rotation, Position &position, Velocity &velocity)
     {
         // start delta model
             // start DeltaLocal
@@ -93,8 +93,8 @@ namespace gpudrive
         float speed = velocity.linear.length();
         // x = c * x - s * y
         // y = s * x + c * y
-        float dx = action.dx * cos - action.dy * sin;
-        float dy = action.dx * sin + action.dy * cos;
+        float dx = action.delta.dx * cos - action.delta.dy * sin;
+        float dy = action.delta.dx * sin + action.delta.dy * cos;
             // end DeltaLocal
             // start DeltaGlobal
         position.x = position.x + dx;
@@ -105,9 +105,9 @@ namespace gpudrive
         velocity.linear.y = dy / dt;
         velocity.linear.z = 0;
         velocity.angular = Vector3::zero();
-        velocity.angular.z = action.dyaw / dt; // Is this correct ?
+        velocity.angular.z = action.delta.dyaw / dt; // Is this correct ?
             // end DeltaGlobal
-        float new_yaw = utils::AngleAdd(yaw, action.dyaw);
+        float new_yaw = utils::AngleAdd(yaw, action.delta.dyaw);
         // end delta model
 
         rotation = Quat::angleAxis(new_yaw, madrona::math::up);
@@ -118,12 +118,12 @@ namespace gpudrive
     {
         const float dt{0.1};
 
-        Action action = {0, 0, 0};
+        Action action = {.classic = {0, 0, 0}};
         float speed = velocity.linear.length();
         float target_speed = targetVelocity.linear.length();
 
         // accel = (new_vel - vel) / dt
-        action.acceleration = (target_speed - speed) / dt;
+        action.classic.acceleration = (target_speed - speed) / dt;
 
         float yaw = utils::NormalizeAngle<float>(utils::quatToYaw(rotation));
         float target_yaw = utils::NormalizeAngle<float>(utils::quatToYaw(targetRotation));
@@ -134,14 +134,14 @@ namespace gpudrive
         }
 
         // steering = (new_yaw - yaw) / (speed * dt + 1/2 * accel * dt ** 2)
-        float denominator = speed * dt + 0.5 * action.acceleration * dt * dt;
+        float denominator = speed * dt + 0.5 * action.classic.acceleration * dt * dt;
         if (denominator != 0)
         {
-            action.steering = (target_yaw - yaw) / denominator;
+            action.classic.steering = (target_yaw - yaw) / denominator;
         }
         else
         {
-            action.steering = 0;
+            action.classic.steering = 0;
         }
         
         return action;

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -33,10 +33,17 @@ static inline void resetAgent(Engine &ctx, Entity agent) {
     ctx.get<Rotation>(agent) = Quat::angleAxis(heading, madrona::math::up);
     ctx.get<Velocity>(agent) = {
         Vector3{.x = xVelocity, .y = yVelocity, .z = 0}, Vector3::zero()};
-    ctx.get<Action>(agent) =
-        Action{.acceleration = 0, .steering = 0, .headAngle = 0};
-    ctx.get<DeltaAction>(agent) =
-        DeltaAction{.dx = 0, .dy = 0, .dyaw = 0};
+    switch (ctx.data().params.dynamicsModel) {
+        case DynamicsModel::Classic:
+            ctx.get<Action>(agent) = Action{.classic = {0, 0, 0}};
+            break;
+        case DynamicsModel::InvertibleBicycle:
+            ctx.get<Action>(agent) = Action{.classic = {0, 0, 0}};
+            break;
+        case DynamicsModel::DeltaLocal:
+            ctx.get<DeltaAction>(agent) = DeltaAction{.dx = 0, .dy = 0, .dyaw = 0};
+            break;
+    }
     ctx.get<StepsRemaining>(agent).t = consts::episodeLen;
     ctx.get<Done>(agent).v = 0;
     ctx.get<Reward>(agent).v = 0;

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -612,19 +612,10 @@ Tensor Manager::actionTensor() const
         {
             impl_->numWorlds,
             consts::kMaxAgentCount,
-            3, // Num_actions
+            ActionExportSize, // Num_actions
         });
 }
 
-Tensor Manager::dActionTensor() const
-{
-    return impl_->exportTensor(ExportID::DeltaAction, TensorElementType::Float32,
-        {
-            impl_->numWorlds,
-            consts::kMaxAgentCount,
-            3, // Num_actions
-        });
-}
 
 Tensor Manager::rewardTensor() const
 {
@@ -806,9 +797,7 @@ Tensor Manager::depthTensor() const
 
 void Manager::setAction(int32_t world_idx, int32_t agent_idx,
                         float acceleration, float steering, float headAngle) {
-    Action action{.acceleration = acceleration,
-                  .steering = steering,
-                  .headAngle = headAngle};
+    Action action{.classicAction = {acceleration, steering, headAngle}};
 
     auto *action_ptr = impl_->agentActionsBuffer + world_idx * consts::kMaxAgentCount + agent_idx;
 

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -93,7 +93,6 @@ struct Manager::Impl {
     EpisodeManager *episodeMgr;
     WorldReset *worldResetBuffer;
     Action *agentActionsBuffer;
-    DeltaAction *agentdActionsBuffer;
     Optional<RenderGPUState> renderGPUState;
     Optional<render::RenderManager> renderMgr;
     int64_t numWorlds{0};
@@ -103,7 +102,6 @@ struct Manager::Impl {
                 EpisodeManager *ep_mgr,
                 WorldReset *reset_buffer,
                 Action *action_buffer,
-                DeltaAction *dAction_buffer,
                 Optional<RenderGPUState> &&render_gpu_state,
                 Optional<render::RenderManager> &&render_mgr,
 		int64_t numWorlds) 
@@ -112,7 +110,6 @@ struct Manager::Impl {
           episodeMgr(ep_mgr),
           worldResetBuffer(reset_buffer),
           agentActionsBuffer(action_buffer),
-          agentdActionsBuffer(dAction_buffer),
           renderGPUState(std::move(render_gpu_state)),
           renderMgr(std::move(render_mgr)),
           numWorlds(numWorlds) {}
@@ -140,12 +137,11 @@ struct Manager::CPUImpl final : Manager::Impl {
                    EpisodeManager *ep_mgr,
                    WorldReset *reset_buffer,
                    Action *action_buffer,
-                   DeltaAction *dAction_buffer,
                    TaskGraphT &&cpu_exec,
                    Optional<RenderGPUState> &&render_gpu_state,
                    Optional<render::RenderManager> &&render_mgr,
 		   int64_t numWorlds)
-        : Impl(mgr_cfg, std::move(phys_loader), ep_mgr, reset_buffer, action_buffer, dAction_buffer,
+        : Impl(mgr_cfg, std::move(phys_loader), ep_mgr, reset_buffer, action_buffer,
                std::move(render_gpu_state), std::move(render_mgr), numWorlds),
           cpuExec(std::move(cpu_exec))
     {}
@@ -179,13 +175,12 @@ struct Manager::CUDAImpl final : Manager::Impl {
                    EpisodeManager *ep_mgr,
                    WorldReset *reset_buffer,
                    Action *action_buffer,
-                   DeltaAction *dAction_buffer,
                    MWCudaExecutor &&gpu_exec,
                    Optional<RenderGPUState> &&render_gpu_state,
                   Optional<render::RenderManager> &&render_mgr,
                    int64_t numWorlds)
         : Impl(mgr_cfg, std::move(phys_loader),
-               ep_mgr, reset_buffer, action_buffer, dAction_buffer,
+               ep_mgr, reset_buffer, action_buffer,
                std::move(render_gpu_state), std::move(render_mgr), numWorlds),  
           gpuExec(std::move(gpu_exec)),
           stepGraph(gpuExec.buildLaunchGraph(TaskGraphID::Step)),
@@ -472,8 +467,6 @@ Manager::Impl * Manager::Impl::init(const Manager::Config &mgr_cfg) {
 
         Action *agent_actions_buffer = 
             (Action *)gpu_exec.getExported((uint32_t)ExportID::Action);
-        DeltaAction *agent_dActions_buffer =
-            (DeltaAction *)gpu_exec.getExported((uint32_t)ExportID::DeltaAction);
         madrona::cu::deallocGPU(paramsDevicePtr);
         for (int64_t i = 0; i < numWorlds; i++) {
           auto &init = world_inits[i];
@@ -486,7 +479,6 @@ Manager::Impl * Manager::Impl::init(const Manager::Config &mgr_cfg) {
             episode_mgr,
             world_reset_buffer,
             agent_actions_buffer,
-            agent_dActions_buffer,
             std::move(gpu_exec),
             std::move(render_gpu_state),
             std::move(render_mgr),
@@ -547,15 +539,12 @@ Manager::Impl * Manager::Impl::init(const Manager::Config &mgr_cfg) {
 
         Action *agent_actions_buffer = 
             (Action *)cpu_exec.getExported((uint32_t)ExportID::Action);
-        DeltaAction *agent_dActions_buffer =
-            (DeltaAction *)cpu_exec.getExported((uint32_t)ExportID::DeltaAction);
         auto cpu_impl = new CPUImpl {
             mgr_cfg,
             std::move(phys_loader),
             episode_mgr,
             world_reset_buffer,
             agent_actions_buffer,
-            agent_dActions_buffer,
             std::move(cpu_exec),
             std::move(render_gpu_state),
             std::move(render_mgr),
@@ -797,7 +786,7 @@ Tensor Manager::depthTensor() const
 
 void Manager::setAction(int32_t world_idx, int32_t agent_idx,
                         float acceleration, float steering, float headAngle) {
-    Action action{.classicAction = {acceleration, steering, headAngle}};
+    Action action{.classic = {acceleration, steering, headAngle}};
 
     auto *action_ptr = impl_->agentActionsBuffer + world_idx * consts::kMaxAgentCount + agent_idx;
 
@@ -807,23 +796,6 @@ void Manager::setAction(int32_t world_idx, int32_t agent_idx,
 #endif
     } else {
         *action_ptr = action;
-    }
-}
-
-void Manager::setDeltaAction(int32_t world_idx, int32_t agent_idx,
-                        float dx, float dy, float dyaw) {
-    DeltaAction dAction{.dx = dx,
-                  .dy = dy,
-                  .dyaw = dyaw};
-
-    auto *dAction_ptr = impl_->agentdActionsBuffer + world_idx * consts::kMaxAgentCount + agent_idx;
-
-    if (impl_->cfg.execMode == ExecMode::CUDA) {
-#ifdef MADRONA_CUDA_SUPPORT
-        cudaMemcpy(dAction_ptr, &dAction, sizeof(DeltaAction), cudaMemcpyHostToDevice);
-#endif
-    } else {
-        *dAction_ptr = dAction;
     }
 }
 

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -52,7 +52,6 @@ public:
     // These functions export Tensor objects that link the ECS
     // simulation state to the python bindings / PyTorch tensors (src/bindings.cpp)
     MGR_EXPORT madrona::py::Tensor actionTensor() const;
-    MGR_EXPORT madrona::py::Tensor dActionTensor() const;
     MGR_EXPORT madrona::py::Tensor rewardTensor() const;
     MGR_EXPORT madrona::py::Tensor doneTensor() const;
     MGR_EXPORT madrona::py::Tensor selfObservationTensor() const;
@@ -76,9 +75,6 @@ public:
     MGR_EXPORT void setAction(int32_t world_idx, int32_t agent_idx,
                               float acceleration, float steering,
                               float headAngle);
-    MGR_EXPORT void setDeltaAction(int32_t world_idx, int32_t agent_idx,
-                              float dx, float dy,
-                              float dyaw);
     // TODO: remove parameters
     MGR_EXPORT std::vector<Shape>
     getShapeTensorFromDeviceMemory(madrona::ExecMode mode);

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -32,7 +32,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     RenderingSystem::registerTypes(registry, cfg.renderBridge);
 
     registry.registerComponent<Action>();
-    registry.registerComponent<DeltaAction>();
     registry.registerComponent<SelfObservation>();
     registry.registerComponent<MapObservation>();
     registry.registerComponent<AgentMapObservations>();
@@ -62,8 +61,6 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
     registry.exportColumn<Agent, Action>(
         (uint32_t)ExportID::Action);
-    registry.exportColumn<Agent, DeltaAction>(
-        (uint32_t)ExportID::DeltaAction);
     registry.exportColumn<Agent, SelfObservation>(
         (uint32_t)ExportID::SelfObservation);
     registry.exportColumn<Agent, AgentMapObservations>(
@@ -236,7 +233,6 @@ inline void agentZeroVelSystem(Engine &,
 
 inline void movementSystem(Engine &e,
                            Action &action,
-                           DeltaAction &dAction,
                            VehicleSize &size,
                            Rotation &rotation,
                            Position &position,
@@ -299,7 +295,7 @@ inline void movementSystem(Engine &e,
                forwardBicycleModel(action, rotation, position, velocity);
                break;
             case DynamicsModel::DeltaLocal:
-               forwardDeltaModel(dAction, rotation, position, velocity);
+               forwardDeltaModel(action, rotation, position, velocity);
                break;
             case DynamicsModel::Classic:
                forwardKinematics(action, size, rotation, position, velocity);
@@ -780,7 +776,6 @@ static void setupStepTasks(TaskGraphBuilder &builder, const Sim::Config &cfg) {
     auto moveSystem = builder.addToGraph<ParallelForNode<Engine,
         movementSystem,
             Action,
-            DeltaAction,
             VehicleSize,
             Rotation,
             Position,

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -221,8 +221,7 @@ inline void collectObservationsSystem(Engine &ctx,
 // Make the agents easier to control by zeroing out their velocity
 // after each step.
 inline void agentZeroVelSystem(Engine &,
-                               Velocity &vel,
-                               Action &)
+                               Velocity &vel)
 {
     vel.linear.x = 0;
     vel.linear.y = 0;
@@ -252,13 +251,13 @@ inline void movementSystem(Engine &e,
         switch (e.data().params.collisionBehaviour) {
             case CollisionBehaviour::AgentStop:
                 done.v = 1;
-                agentZeroVelSystem(e, velocity, action);
+                agentZeroVelSystem(e, velocity);
                 break;
 
             case CollisionBehaviour::AgentRemoved:
                 done.v = 1;
                 position = consts::kPaddingPosition;
-                agentZeroVelSystem(e, velocity, action);
+                agentZeroVelSystem(e, velocity);
                 break;
 
             case CollisionBehaviour::Ignore:

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -17,7 +17,6 @@ class Engine;
 enum class ExportID : uint32_t {
     Reset,
     Action,
-    DeltaAction,
     Reward,
     Done,
     SelfObservation,

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -285,7 +285,6 @@ struct Agent : public madrona::Archetype<
 
     // Input
     Action,
-    DeltaAction,
     // Observations
     SelfObservation,
     AbsoluteSelfObservation,

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -53,7 +53,9 @@ struct WorldReset {
     int32_t reset;
 };
 
-struct Action {
+
+
+struct ClassicAction {
     float acceleration;
     float steering;
     float headAngle;
@@ -64,6 +66,23 @@ struct DeltaAction {
     float dy;
     float dyaw;
 };
+
+struct StateAction {
+    Position position; // 3 floats
+    float yaw; // 1 float
+    Velocity velocity;  // 3 floats
+};
+
+union Action
+{
+    ClassicAction classic;
+    DeltaAction delta;
+    StateAction state;
+};
+
+const size_t ActionExportSize = 3 + 1 + 6;
+
+static_assert(sizeof(Action) == sizeof(float) * ActionExportSize);
 
 // Per-agent reward
 // Exported as an [N * A, 1] float tensor to training code
@@ -195,10 +214,9 @@ struct Trajectory {
     float headings[consts::kTrajectoryLength];
     float valids[consts::kTrajectoryLength];
     Action inverseActions[consts::kTrajectoryLength];
-    DeltaAction inverseDeltaActions[consts::kTrajectoryLength];
 };
 
-const size_t TrajectoryExportSize = 2 * 2 * consts::kTrajectoryLength + 2 * consts::kTrajectoryLength + 6 * consts::kTrajectoryLength;
+const size_t TrajectoryExportSize = 2 * 2 * consts::kTrajectoryLength + 2 * consts::kTrajectoryLength + ActionExportSize * consts::kTrajectoryLength;
 
 static_assert(sizeof(Trajectory) == sizeof(float) * TrajectoryExportSize);
 

--- a/tests/test_delta_model.py
+++ b/tests/test_delta_model.py
@@ -33,18 +33,16 @@ def test_forward_inverse_delta_dynamics(sim_init):
     valid_agent_idx = 1
     done_tensor = sim.done_tensor().to_torch()
     expert_trajectory_tensor = sim.expert_trajectory_tensor().to_torch()
-    delta_action_tensor = sim.delta_action_tensor().to_torch()
+    action_tensor = sim.action_tensor().to_torch()
     absolute_obs = sim.absolute_self_observation_tensor().to_torch()
     self_obs = sim.self_observation_tensor().to_torch()
-    delta_actions = torch.zeros_like(delta_action_tensor)
+    actions = torch.zeros_like(action_tensor)
 
     traj = expert_trajectory_tensor[:,valid_agent_idx].squeeze()
     pos = traj[:2*91].view(91,2)
     vel = traj[2*91:4*91].view(91,2)
     headings = traj[4*91:5*91].view(91,1)
-    invDeltaActions = traj[9*91:].view(91,3)
-    invActions = traj[6*91:9*91].view(91,3)
-    print('INVdELTAaCTION', invDeltaActions[:2])
+    invActions = traj[6*91:16*91].view(91,10)
     print('invActions', invActions[:2])
     position = absolute_obs[0,valid_agent_idx,:2]
     heading = absolute_obs[0,valid_agent_idx,7]
@@ -54,8 +52,8 @@ def test_forward_inverse_delta_dynamics(sim_init):
     assert pytest.approx(heading.item(), abs=1e-2) == headings[0].item(), f"Heading mismatch: {heading.item()} vs {headings[0].item()}"
     assert pytest.approx(speed.item(), abs=1e-2) == torch.norm(vel[0]).item(), f"Speed mismatch: {speed.item()} vs {torch.norm(vel[0]).item()}"
 
-    delta_actions[:,valid_agent_idx,:] = invDeltaActions[0]
-    delta_action_tensor.copy_(delta_actions)
+    actions[:,valid_agent_idx,:3] = invActions[0,:3]
+    action_tensor.copy_(actions)
     sim.step()
     
     assert torch.allclose(position, pos[1], atol=2e-2), f"Position mismatch: {position} vs {pos[1]} at step {1}"

--- a/tests/test_waymax_model.py
+++ b/tests/test_waymax_model.py
@@ -41,7 +41,7 @@ def test_forward_inverse_dynamics(sim_init):
     pos = traj[:2*91].view(91,2)
     vel = traj[2*91:4*91].view(91,2)
     headings = traj[4*91:5*91].view(91,1)
-    invActions = traj[6*91:9*91].view(91,3)
+    invActions = traj[6*91:16*91].view(91,10)
     print('invActions', invActions[:2])
     position = absolute_obs[0,valid_agent_idx,:2]
     heading = absolute_obs[0,valid_agent_idx,7]
@@ -50,7 +50,7 @@ def test_forward_inverse_dynamics(sim_init):
     assert pytest.approx(heading.item(), abs=1e-2) == headings[0].item(), f"Heading mismatch: {heading.item()} vs {headings[0].item()}"
     assert pytest.approx(speed.item(), abs=1e-2) == torch.norm(vel[0]).item(), f"Speed mismatch: {speed.item()} vs {torch.norm(vel[0]).item()}"
 
-    actions[:,valid_agent_idx,:] = invActions[0]
+    actions[:,valid_agent_idx,:3] = invActions[0,:3]
     action_tensor.copy_(actions)
     sim.step()
     


### PR DESCRIPTION
Since we now aim to support multiple dynamics models, each of the model come with their own unique set of action spaces. However, if we tried to make a new data structure for each action space we'd introduce a lot of bloat in the code. This PR makes the Action struct a union of individual action spaces. At any given time only one action space is active. This allows us to reduce the bloat, pass in only one Action component to systems, and also easily be able to add in new action spaces as needed. The new types looks like this - 

```
struct ClassicAction {
    float acceleration;
    float steering;
    float headAngle;
};

struct DeltaAction {
    float dx;
    float dy;
    float dyaw;
};

struct StateAction {
    Position position;
    float yaw;
    Velocity velocity;  
};

union Action
{
    ClassicAction classic;
    DeltaAction delta;
    StateAction state;
};
```

As part of these changes, the Action tensor now is of the size of the largest type defined in the union. So for eg, before the Action tensor was of shape 3, but now it is of shape (3+1+6) as the StateAction is the biggest type here. As such, to use the action tensor, it would be important to know which bicycle model is being used, and the corresponding type size. 

for eg. -
```
# for classic model, we can do the following 
action_tensor[:, :, :3] = classic_action_values

# for state model, we can do 
action_tensor[:, :, :] = state_action_values 

# for an aribitrary model, 
action_tensor[:, :, :k] = ... # where in k is the size of that type. 
```