### PR TITLE
Fix invalid whitespace in bindings.cpp

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -53,7 +53,7 @@ namespace gpudrive
             .def_rw("maxNumControlledVehicles", &Parameters::maxNumControlledVehicles)
             .def_rw("IgnoreNonVehicles", &Parameters::IgnoreNonVehicles)
             .def_rw("roadObservationAlgorithm", &Parameters::roadObservationAlgorithm)
-            .def_rw("initOnlyValidAgentsAtFirstStep ", &Parameters::initOnlyValidAgentsAtFirstStep)
+            .def_rw("initOnlyValidAgentsAtFirstStep", &Parameters::initOnlyValidAgentsAtFirstStep)
             .def_rw("dynamicsModel", &Parameters::dynamicsModel)
             .def_rw("enableLidar", &Parameters::enableLidar)
             .def_rw("disableClassicalObs", &Parameters::disableClassicalObs)


### PR DESCRIPTION
There is a whitespace in `initOnlyValidAgentsAtFirstStep`