### PR TITLE
Debug sb3_wrapper.py when run with num_worlds = 1

### DIFF
--- a/pygpudrive/env/wrappers/sb3_wrapper.py
+++ b/pygpudrive/env/wrappers/sb3_wrapper.py
@@ -134,7 +134,7 @@ class SB3MultiAgentEnv(VecEnv):
             == self.controlled_agent_mask.sum(dim=1)
         )[0]
 
-        if done_worlds.any().item():
+        if len(done_worlds) > 0:
             self._update_info_dict(info, done_worlds)
             self.num_episodes += len(done_worlds)
             self._env.sim.reset(done_worlds.tolist())
@@ -155,7 +155,7 @@ class SB3MultiAgentEnv(VecEnv):
         self.dead_agent_mask = torch.logical_or(self.dead_agent_mask, done)
 
         # Now override the dead agent mask for the reset worlds
-        if done_worlds.any().item():
+        if len(done_worlds) > 0:
             for world_idx in done_worlds:
                 self.dead_agent_mask[
                     world_idx, :


### PR DESCRIPTION
This PR enables to run ippo with 1 scene. Before, when you run `python baselines/ippo/run_sb3_ppo.py` with `num_worlds: 1` in `baselines/ippo/config.py`, gets error because condition in the line 157 returns the `False` since `done_world = [0]`. Therefore, `self.dead_agent_mask` will not be updated.

https://github.com/Emerge-Lab/gpudrive/blob/b884ea558f2a2723ebff47de6380079c9ceca68c/pygpudrive/env/wrappers/sb3_wrapper.py#L158

Propose to change like (unsqueeze, not working)

`if len(done_worlds) > 0:`