### PR TITLE
FIX&FEAT: fix bug of random scene selection and allow seed specification

### DIFF
--- a/pygpudrive/env/config.py
+++ b/pygpudrive/env/config.py
@@ -135,12 +135,14 @@ class SceneConfig:
         discipline (SelectionDiscipline): Method for selecting scenes.
         k_unique_scenes (Optional[int]): Number of unique scenes if using
             K_UNIQUE_N discipline.
+        seed (Optional[int]): Seed for random scene selection.
     """
 
     path: str
     num_scenes: int
     discipline: SelectionDiscipline = SelectionDiscipline.PAD_N
     k_unique_scenes: Optional[int] = None
+    seed: Optional[int] = None
 
 
 class RenderMode(Enum):

--- a/pygpudrive/env/scene_selector.py
+++ b/pygpudrive/env/scene_selector.py
@@ -24,7 +24,8 @@ def select_scenes(config):
         )
 
     def random_sample(k):
-        rand = random.Random(0x5CA1AB1E)
+        seed = config.seed if config.seed is not None else 0x5CA1AB1E
+        rand = random.Random(seed)
         return rand.sample(all_scenes, k)
 
     def repeat_to_N(scenes):
@@ -36,7 +37,7 @@ def select_scenes(config):
             selected_scenes = all_scenes[: config.num_scenes]
             selected_scenes = all_scenes[: config.num_scenes]
         case SelectionDiscipline.RANDOM_N:
-            selected_scenes = random_sample(all_scenes)
+            selected_scenes = random_sample(config.num_scenes)
         case SelectionDiscipline.PAD_N:
             selected_scenes = repeat_to_N(all_scenes)
         case SelectionDiscipline.EXACT_N:


### PR DESCRIPTION
Current `SelectionDiscipline.RANDOM_N` mistakenly passed `all_scenes` instead of `num_scenes`. And the random seed is fixed, which seems not very convenient.