### PR TITLE
Add new MapType enum

### DIFF
--- a/src/init.hpp
+++ b/src/init.hpp
@@ -43,6 +43,7 @@ namespace gpudrive
         // std::array<MapPosition, MAX_POSITIONS> geometry;
         MapVector2 geometry[MAX_GEOMETRY];
         uint32_t id;
+        MapType mapType;
         EntityType type;
         uint32_t numPoints;
         MapVector2 mean;

--- a/src/json_serialization.hpp
+++ b/src/json_serialization.hpp
@@ -207,6 +207,24 @@ namespace gpudrive
             road.id = j.at("id").get<uint32_t>();
         }
 
+        if (j.contains("map_element_id"))
+        {
+            auto mapElementId = j.at("map_element_id").get<int32_t>();
+
+            if(mapElementId == 4 or mapElementId >= static_cast<int32_t>(MapType::NUM_TYPES) or mapElementId < -1)
+            {
+                road.mapType = MapType::UNKNOWN;
+            }
+            else
+            {
+                road.mapType = static_cast<MapType>(mapElementId);
+            }
+        }
+        else
+        {
+            road.mapType = MapType::UNKNOWN;
+        }
+
         for (int i = 0; i < road.numPoints; i++)
         {
             road.mean.x += (road.geometry[i].x - road.mean.x)/(i+1);

--- a/src/knn.hpp
+++ b/src/knn.hpp
@@ -115,7 +115,8 @@ void selectKNearestRoadEntities(Engine &ctx, const Rotation &referenceRotation,
                                      ctx.get<madrona::base::Rotation>(roads[i]),
                                      ctx.get<madrona::base::Scale>(roads[i]),
                                      ctx.get<gpudrive::EntityType>(roads[i]),
-                                     static_cast<float>(ctx.get<RoadMapId>(roads[i]).id));
+                                     static_cast<float>(ctx.get<RoadMapId>(roads[i]).id),
+                                     ctx.get<MapType>(roads[i]));
   }
 
   if (roadCount < K) {
@@ -132,7 +133,8 @@ void selectKNearestRoadEntities(Engine &ctx, const Rotation &referenceRotation,
         ctx.get<madrona::base::Rotation>(roads[roadIdx]),
         ctx.get<madrona::base::Scale>(roads[roadIdx]),
         ctx.get<gpudrive::EntityType>(roads[roadIdx]),
-        static_cast<float>(ctx.get<RoadMapId>(roads[roadIdx]).id));
+        static_cast<float>(ctx.get<RoadMapId>(roads[roadIdx]).id),
+        ctx.get<MapType>(roads[roadIdx]));
 
     const auto &kthNearestObservation = heap[0];
     bool isCurrentObservationCloser =

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -144,9 +144,11 @@ static inline Entity createAgent(Engine &ctx, const MapObject &agentInit) {
     return agent;
 }
 
-static Entity makeRoadEdge(Engine &ctx, const MapVector2 &p1,
-                           const MapVector2 &p2, const EntityType &type, const uint32_t &id) {                    
-    float z = 1 + (type == EntityType::RoadEdge ? consts::lidarRoadEdgeOffset : consts::lidarRoadLineOffset);
+static Entity makeRoadEdge(Engine &ctx, const MapRoad &roadInit, CountT j) {                    
+    const MapVector2 &p1 = roadInit.geometry[j];
+    const MapVector2 &p2 = roadInit.geometry[j+1]; // This is guaranteed to be within bounds
+
+    float z = 1 + (roadInit.type == EntityType::RoadEdge ? consts::lidarRoadEdgeOffset : consts::lidarRoadLineOffset);
 
     Vector3 start{.x = p1.x - ctx.data().mean.x, .y = p1.y - ctx.data().mean.y, .z = z};
     Vector3 end{.x = p2.x - ctx.data().mean.x, .y = p2.y - ctx.data().mean.y, .z = z};
@@ -157,11 +159,9 @@ static Entity makeRoadEdge(Engine &ctx, const MapVector2 &p1,
     auto pos = Vector3{.x = (start.x + end.x)/2, .y = (start.y + end.y)/2, .z = z};
     auto rot = Quat::angleAxis(atan2(end.y - start.y, end.x - start.x), madrona::math::up);
     auto scale = Diag3x3{.d0 = start.distance(end)/2, .d1 = 0.1, .d2 = 0.1};
-    setRoadEntitiesProps(ctx, road_edge, pos, rot, scale, type, ObjectID{(int32_t)SimObject::Cube}, ResponseType::Static, id);
+    setRoadEntitiesProps(ctx, road_edge, pos, rot, scale, roadInit.type, ObjectID{(int32_t)SimObject::Cube}, ResponseType::Static, roadInit.id, roadInit.mapType);
     registerRigidBodyEntity(ctx, road_edge, SimObject::Cube);
-
     
-
     return road_edge;
 }
 
@@ -169,9 +169,14 @@ float calculateDistance(float x1, float y1, float x2, float y2) {
     return sqrt(pow(x2 - x1, 2) + pow(y2 - y1, 2));
 }
 
-static Entity makeCube(Engine &ctx, const MapVector2 &p1, const MapVector2 &p2, const MapVector2 &p3,
-                            const MapVector2 &p4, const EntityType &type, const uint32_t &id) {
-    MapVector2 points[] = {p1, p2, p3, p4};
+static Entity makeCube(Engine &ctx, const MapRoad &roadInit) {
+
+    MapVector2 points[] = {
+        roadInit.geometry[0],
+        roadInit.geometry[1],
+        roadInit.geometry[2],
+        roadInit.geometry[3]
+    };
 
     // Calculate distances between consecutive points
     float lengths[4];
@@ -200,17 +205,25 @@ static Entity makeCube(Engine &ctx, const MapVector2 &p1, const MapVector2 &p2, 
     auto speed_bump = ctx.makeRenderableEntity<PhysicsEntity>();
     ctx.get<RoadInterfaceEntity>(speed_bump).e = ctx.makeEntity<RoadInterface>();
 
-    auto pos = Vector3{.x = (p1.x + p2.x + p3.x + p4.x)/4 - ctx.data().mean.x, .y = (p1.y + p2.y + p3.y + p4.y)/4 - ctx.data().mean.y, .z = 1 + consts::lidarRoadLineOffset};
+    float sum_x = 0.0f;
+    float sum_y = 0.0f;
+
+    for (const auto& point : points) {
+        sum_x += point.x;
+        sum_y += point.y;
+    }
+
+    auto pos = Vector3{.x = sum_x/4 - ctx.data().mean.x, .y = sum_y/4 - ctx.data().mean.y, .z = 1 + consts::lidarRoadLineOffset};
     auto rot = Quat::angleAxis(angle, madrona::math::up);
     auto scale = Diag3x3{.d0 = lengths[maxLength_i]/2, .d1 = lengths[minLength_i]/2, .d2 = 0.1};
-    setRoadEntitiesProps(ctx, speed_bump, pos, rot, scale, type, ObjectID{(int32_t)SimObject::SpeedBump}, ResponseType::Static, id);
+    setRoadEntitiesProps(ctx, speed_bump, pos, rot, scale, roadInit.type, ObjectID{(int32_t)SimObject::SpeedBump}, ResponseType::Static, roadInit.id, roadInit.mapType);
     registerRigidBodyEntity(ctx, speed_bump, SimObject::SpeedBump);
     return speed_bump;
 }
 
-static Entity makeStopSign(Engine &ctx, const MapVector2 &p1, const uint32_t &id) {
-    float x1 = p1.x;
-    float y1 = p1.y;
+static Entity makeStopSign(Engine &ctx, const MapRoad &roadInit) {
+    float x1 = roadInit.geometry[0].x;
+    float y1 = roadInit.geometry[0].y;
 
     auto stop_sign = ctx.makeRenderableEntity<PhysicsEntity>();
     ctx.get<RoadInterfaceEntity>(stop_sign).e = ctx.makeEntity<RoadInterface>();
@@ -218,7 +231,7 @@ static Entity makeStopSign(Engine &ctx, const MapVector2 &p1, const uint32_t &id
     auto pos = Vector3{.x = x1 - ctx.data().mean.x, .y = y1 - ctx.data().mean.y, .z = 1};
     auto rot = Quat::angleAxis(0, madrona::math::up);
     auto scale = Diag3x3{.d0 = 0.2, .d1 = 0.2, .d2 = 1};
-    setRoadEntitiesProps(ctx, stop_sign, pos, rot, scale, EntityType::StopSign, ObjectID{(int32_t)SimObject::StopSign}, ResponseType::Static, id);
+    setRoadEntitiesProps(ctx, stop_sign, pos, rot, scale, EntityType::StopSign, ObjectID{(int32_t)SimObject::StopSign}, ResponseType::Static, roadInit.id, roadInit.mapType);
     registerRigidBodyEntity(ctx, stop_sign, SimObject::StopSign);
     return stop_sign;
 }
@@ -235,7 +248,7 @@ static inline void createRoadEntities(Engine &ctx, const MapRoad &roadInit, Coun
             size_t numPoints = roadInit.numPoints;
             for (size_t j = 1; j <= numPoints - 1; j++)
             {
-                auto road = ctx.data().roads[idx] = makeRoadEdge(ctx, roadInit.geometry[j - 1], roadInit.geometry[j], roadInit.type, roadInit.id);
+                auto road = ctx.data().roads[idx] = makeRoadEdge(ctx, roadInit, j-1);
                 ctx.data().road_ifaces[idx++] = ctx.get<RoadInterfaceEntity>(road).e;
                 if (idx >= consts::kMaxRoadEntityCount) return;
             }
@@ -246,7 +259,7 @@ static inline void createRoadEntities(Engine &ctx, const MapRoad &roadInit, Coun
         {
             assert(roadInit.numPoints >= 4);
             // TODO: Speed Bump are not guranteed to have 4 points. Need to handle this case.
-            auto road = ctx.data().roads[idx] = makeCube(ctx, roadInit.geometry[0], roadInit.geometry[1], roadInit.geometry[2], roadInit.geometry[3], roadInit.type, roadInit.id);
+            auto road = ctx.data().roads[idx] = makeCube(ctx, roadInit);
             ctx.data().road_ifaces[idx++] = ctx.get<RoadInterfaceEntity>(road).e;
             break;
         }
@@ -254,7 +267,7 @@ static inline void createRoadEntities(Engine &ctx, const MapRoad &roadInit, Coun
         {
             assert(roadInit.numPoints >= 1);
             // TODO: Stop Sign are not guranteed to have 1 point. Need to handle this case.
-            auto road = ctx.data().roads[idx] = makeStopSign(ctx, roadInit.geometry[0], roadInit.id);
+            auto road = ctx.data().roads[idx] = makeStopSign(ctx, roadInit);
             ctx.data().road_ifaces[idx++] = ctx.get<RoadInterfaceEntity>(road).e;
             break;
         }
@@ -269,7 +282,7 @@ static void createFloorPlane(Engine &ctx)
     setRoadEntitiesProps(ctx, ctx.data().floorPlane, Vector3{.x = 0, .y = 0, .z = 0},
                          Quat::angleAxis(0, madrona::math::up),
                          Diag3x3{.d0 = 100, .d1 = 100, .d2 = 0.1},
-                         EntityType::None, ObjectID{(int32_t)SimObject::Plane}, ResponseType::Static, 0);
+                         EntityType::None, ObjectID{(int32_t)SimObject::Plane}, ResponseType::Static, 0, MapType::UNKNOWN);
     registerRigidBodyEntity(ctx, ctx.data().floorPlane, SimObject::Plane);
 }
 

--- a/src/level_gen.hpp
+++ b/src/level_gen.hpp
@@ -45,7 +45,8 @@ void destroyWorld(Engine &ctx);
                                             EntityType type,
                                             ObjectID objId,
                                             ResponseType responseType, 
-                                            uint32_t roadIdx)
+                                            uint32_t roadIdx,
+                                            MapType mapType)
     {
         ctx.get<Position>(road) = pos;
         ctx.get<Rotation>(road) = rot;
@@ -54,11 +55,13 @@ void destroyWorld(Engine &ctx);
         ctx.get<ObjectID>(road) = objId;
         ctx.get<ResponseType>(road) = responseType;
         ctx.get<RoadMapId>(road).id = roadIdx;
+        ctx.get<MapType>(road) = mapType;
         ctx.get<MapObservation>(ctx.get<RoadInterfaceEntity>(road).e) = MapObservation{.position = pos.xy(),
                                                                                        .scale = scale,
                                                                                        .heading = utils::quatToYaw(rot),
                                                                                        .type = (float)type,
-                                                                                       .id = static_cast<float>(roadIdx)};
+                                                                                       .id = static_cast<float>(roadIdx),
+                                                                                       .mapType = static_cast<float>(mapType)};
     }
 
 } // namespace gpudrive

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -54,6 +54,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerComponent<RoadInterfaceEntity>();
     registry.registerComponent<AgentID>();
     registry.registerComponent<RoadMapId>();
+    registry.registerComponent<MapType>();
 
     registry.registerSingleton<WorldReset>();
     registry.registerSingleton<Shape>();
@@ -246,7 +247,7 @@ inline void collectMapObservationsSystem(Engine &ctx,
         }
 
         map_obs.obs[arrIndex] = referenceFrame.observationOf(
-            roadPos, roadRot, ctx.get<Scale>(road), ctx.get<EntityType>(road), static_cast<float>(ctx.get<RoadMapId>(road).id));
+            roadPos, roadRot, ctx.get<Scale>(road), ctx.get<EntityType>(road), static_cast<float>(ctx.get<RoadMapId>(road).id), ctx.get<MapType>(road));
         arrIndex++;
     }
     while (arrIndex < consts::kMaxAgentMapObservationsCount) {

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -37,6 +37,33 @@ namespace gpudrive
         NumTypes,
     };
 
+    enum class MapType : int32_t
+    {
+        LANE_UNDEFINED = 0,
+        LANE_FREEWAY = 1,
+        LANE_SURFACE_STREET = 2,
+        LANE_BIKE_LANE = 3,
+        // Original definition skips 4
+        ROAD_LINE_UNKNOWN = 5,
+        ROAD_LINE_BROKEN_SINGLE_WHITE = 6,
+        ROAD_LINE_SOLID_SINGLE_WHITE = 7,
+        ROAD_LINE_SOLID_DOUBLE_WHITE = 8,
+        ROAD_LINE_BROKEN_SINGLE_YELLOW = 9,
+        ROAD_LINE_BROKEN_DOUBLE_YELLOW = 10,
+        ROAD_LINE_SOLID_SINGLE_YELLOW = 11,
+        ROAD_LINE_SOLID_DOUBLE_YELLOW = 12,
+        ROAD_LINE_PASSING_DOUBLE_YELLOW = 13,
+        ROAD_EDGE_UNKNOWN = 14,
+        ROAD_EDGE_BOUNDARY = 15,
+        ROAD_EDGE_MEDIAN = 16,
+        STOP_SIGN = 17,
+        CROSSWALK = 18,
+        SPEED_BUMP = 19,
+        DRIVEWAY = 20,  // New datatype in v1.2.0: Driveway entrances
+        UNKNOWN = -1,
+        NUM_TYPES = 21,
+    };
+
 struct AgentID {
     int32_t id;
 };
@@ -166,6 +193,7 @@ struct ResetMap {
         float heading;
         float type;
         float id;
+        float mapType;
 
         static inline MapObservation zero()
         {
@@ -174,12 +202,13 @@ struct ResetMap {
                 .scale = madrona::math::Diag3x3{0, 0, 0},
                 .heading = 0,
                 .type = static_cast<float>(EntityType::None),
-                .id = -1
+                .id = -1,
+                .mapType = static_cast<float>(MapType::UNKNOWN)
             };       
         }
     };
 
-    const size_t MapObservationExportSize = 8;
+    const size_t MapObservationExportSize = 9;
 
     static_assert(sizeof(MapObservation) == sizeof(float) * MapObservationExportSize);
 
@@ -227,7 +256,7 @@ struct ResetMap {
         MapObservation obs[consts::kMaxAgentMapObservationsCount];
     };
 
-    const size_t AgentMapObservationExportSize = 8;
+    const size_t AgentMapObservationExportSize = MapObservationExportSize;
 
     static_assert(sizeof(AgentMapObservations) ==
                   sizeof(float) * consts::kMaxAgentMapObservationsCount *
@@ -414,6 +443,7 @@ struct ResetMap {
                                RoadInterfaceEntity,
                                EntityType,
                                RoadMapId,
+                               MapType,
                                madrona::render::Renderable>
     {
     };

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -33,12 +33,13 @@ public:
   gpudrive::MapObservation
   observationOf(const madrona::math::Vector3 &position,
                 const madrona::base::Rotation &rotation, const Scale &scale,
-                gpudrive::EntityType type, float id) const {
+                gpudrive::EntityType type, float id, MapType mapType = MapType::UNKNOWN) const {
     return gpudrive::MapObservation{.position = relative(position),
                                     .scale = scale,
                                     .heading = relative(rotation),
                                     .type = static_cast<float>(type),
-                                    .id = static_cast<float>(id)};
+                                    .id = static_cast<float>(id),
+                                    .mapType = static_cast<float>(mapType)};
   }
 
   float distanceTo(const madrona::math::Vector3 &position) const {


### PR DESCRIPTION
This PR adds in a new `MapType` enum. Instead of modifying existing `EntityType` enum which is depended upon by a lot of code throughout, I just added in a new type specifically for the Map objects.
Also, I got in a bit of code refactor in to make it look nicer. 