### PR TITLE
Refactor mean to singleton and export

### DIFF
--- a/examples/tutorials/02_simulator_demo.ipynb
+++ b/examples/tutorials/02_simulator_demo.ipynb
@@ -139,7 +139,7 @@
     {
      "data": {
       "text/plain": [
-       "(torch.Size([1, 128, 7]), device(type='cpu'))"
+       "(torch.Size([1, 32, 7]), device(type='cpu'))"
       ]
      },
      "execution_count": 6,
@@ -175,7 +175,7 @@
     {
      "data": {
       "text/plain": [
-       "((1, 128, 7), {CpuDevice(id=0)})"
+       "((1, 32, 7), {CpuDevice(id=0)})"
       ]
      },
      "execution_count": 7,
@@ -221,10 +221,12 @@
       "reward_tensor\n",
       "rgb_tensor\n",
       "self_observation_tensor\n",
+      "set_maps\n",
       "shape_tensor\n",
       "step\n",
       "steps_remaining_tensor\n",
-      "valid_state_tensor\n"
+      "valid_state_tensor\n",
+      "world_means_tensor\n"
      ]
     }
    ],
@@ -292,7 +294,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Controlled state tensor has a shape of (num_worlds, max_num_agents_in_scene, 1):  torch.Size([1, 128, 1])\n"
+      "Controlled state tensor has a shape of (num_worlds, max_num_agents_in_scene, 1):  torch.Size([1, 32, 1])\n"
      ]
     }
    ],
@@ -313,10 +315,6 @@
      "data": {
       "text/plain": [
        "tensor([1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
        "        0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32)"
       ]
      },
@@ -379,7 +377,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Action tensor has a shape of (num_worlds, max_num_agents_in_scene, 3): torch.Size([1, 128, 10])\n"
+      "Action tensor has a shape of (num_worlds, max_num_agents_in_scene, 3): torch.Size([1, 32, 10])\n"
      ]
     }
    ],
@@ -449,7 +447,7 @@
       "maxNumControlledAgents: 10000\n",
       "observationRadius   : 0.0\n",
       "polylineReductionThreshold: 0.0\n",
-      "rewardParams        : <gpudrive.RewardParams object at 0x7f3a8c4a8670>\n",
+      "rewardParams        : <gpudrive.RewardParams object at 0x7f9d62bb6510>\n",
       "Reward parameters:\n",
       "    distanceToExpertThreshold: 0.0\n",
       "    distanceToGoalThreshold: 0.0\n",
@@ -531,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +625,6 @@
     "* `isStaticAgentControlled`: Controls if agents like parked vehicles that are already at their goals should be allowed to be controlled or set as static. Default: `false`.\n",
     "* `enableLidar`: Enables lidar observations.\n",
     "* `disableClassicalObs`: Disables setting `PartnerObservations` and `AgentMapObservations`. Generally used to speed up the simulator if lidar observations are enabled and the above observations are not used. Default: `false`.\n",
-    "* `useWayMaxModel`: Sets if the WayMax dynamics model should be used. Default: `false`.\n",
     "\n",
     "#### Types of Objects\n",
     "\n",
@@ -649,7 +646,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "### Other exported tensors\n",
+    "\n",
+    "- By default, the x, y, z coordinates are de-meaned to center everything at 0. To revert back to the original coordinates, we export the `world_means_tensor`. \n",
+    "    - Shape:  (`num_worlds`, 3)"
+   ]
   }
  ],
  "metadata": {

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -125,7 +125,8 @@ namespace gpudrive
             .def("depth_tensor", &Manager::depthTensor)
             .def("response_type_tensor", &Manager::responseTypeTensor)
             .def("expert_trajectory_tensor", &Manager::expertTrajectoryTensor)
-            .def("set_maps", &Manager::setMaps);
+            .def("set_maps", &Manager::setMaps)
+            .def("world_means_tensor", &Manager::worldMeansTensor);
     }
 
 }

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
     auto controlledStatePrinter = mgr.controlledStateTensor().makePrinter();
     auto agent_map_obs_printer = mgr.agentMapObservationsTensor().makePrinter();
     auto info_printer = mgr.infoTensor().makePrinter();
+    auto means_printer = mgr.worldMeansTensor().makePrinter();
 
     auto printObs = [&]() {
         // printf("Self\n");
@@ -103,11 +104,14 @@ int main(int argc, char *argv[])
         // printf("Controlled State\n");
         // controlledStatePrinter.print();
 
-        printf("Agent Map Obs\n");
-        agent_map_obs_printer.print();
+        // printf("Agent Map Obs\n");
+        // agent_map_obs_printer.print();
 
         // printf("Info\n");
         // info_printer.print();
+
+        printf("Means\n");
+        means_printer.print();
     };
 
     auto worldToShape =

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -667,6 +667,15 @@ Tensor Manager::rewardTensor() const
     return impl_->exportTensor(ExportID::Reward, TensorElementType::Float32,
                                {
                                    impl_->numWorlds,
+                                   WorldMeansExportSize,
+                               });
+}
+
+Tensor Manager::worldMeansTensor() const
+{
+    return impl_->exportTensor(ExportID::WorldMeans, TensorElementType::Float32,
+                               {
+                                   impl_->numWorlds,
                                    consts::kMaxAgentCount,
                                    1,
                                });

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -676,8 +676,7 @@ Tensor Manager::worldMeansTensor() const
     return impl_->exportTensor(ExportID::WorldMeans, TensorElementType::Float32,
                                {
                                    impl_->numWorlds,
-                                   consts::kMaxAgentCount,
-                                   1,
+                                   WorldMeansExportSize,
                                });
 }
 

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -67,6 +67,7 @@ public:
     MGR_EXPORT madrona::py::Tensor infoTensor() const;
     MGR_EXPORT madrona::py::Tensor responseTypeTensor() const;
     MGR_EXPORT madrona::py::Tensor expertTrajectoryTensor() const;
+    MGR_EXPORT madrona::py::Tensor worldMeansTensor() const;
     madrona::py::Tensor rgbTensor() const;
     madrona::py::Tensor depthTensor() const;
     // These functions are used by the viewer to control the simulation

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -60,6 +60,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerSingleton<Shape>();
     registry.registerSingleton<Map>();
     registry.registerSingleton<ResetMap>();
+    registry.registerSingleton<WorldMeans>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
@@ -71,6 +72,8 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<Shape>((uint32_t)ExportID::Shape);
     registry.exportSingleton<Map>((uint32_t)ExportID::Map);
     registry.exportSingleton<ResetMap>((uint32_t)ExportID::ResetMap);
+    registry.exportSingleton<WorldMeans>((uint32_t)ExportID::WorldMeans);
+    
     registry.exportColumn<AgentInterface, Action>(
         (uint32_t)ExportID::Action);
     registry.exportColumn<AgentInterface, SelfObservation>(

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -35,6 +35,7 @@ enum class ExportID : uint32_t {
     Trajectory,
     Map,
     ResetMap,
+    WorldMeans,
     NumExports
 };
 
@@ -129,8 +130,6 @@ struct Sim : public madrona::WorldBase {
     Entity camera_agent;
 
     madrona::CountT numControlledAgents;
-
-    madrona::math::Vector2 mean;
 
     Parameters params;
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -88,10 +88,19 @@ struct AgentID {
         int32_t reset;
     };
 
-struct ResetMap {
-    int32_t reset;
-};   
-     struct ClassicAction
+    struct ResetMap {
+        int32_t reset;
+    };   
+
+    struct WorldMeans {
+        madrona::math::Vector3 mean; // TODO: Z is 0 for now, but can be used for 3D in future
+    };
+
+    const size_t WorldMeansExportSize = 3;
+
+    static_assert(sizeof(WorldMeans) == sizeof(float) * WorldMeansExportSize);
+
+    struct ClassicAction
     {
         float acceleration;
         float steering;


### PR DESCRIPTION
This PR refactors the means to be a singleton component on a world level. It allows us to export the means. 

Shape exported - `{num_worlds, 3}`. 3 values for x, y and z. 

TODO for future commit - I have currently set the shape as 3D to allow for easy integration of z axis in the future. This is so that the shape wont change in the future and any python dependencies on the shape will not break code. Z mean is set to 0 for now so it wont affect any computation.