### PR TITLE
Fixed resets for viewer

### DIFF
--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -586,13 +586,13 @@ void Manager::reset(std::vector<int32_t> worldsToReset) {
 
     impl_->reset();
 
-    if (impl_->renderMgr.has_value()) {
-        impl_->renderMgr->readECS();
-    }
+    // if (impl_->renderMgr.has_value()) {
+    //     impl_->renderMgr->readECS();
+    // }
 
-    if (impl_->cfg.enableBatchRenderer) {
-        impl_->renderMgr->batchRender();
-    }
+    // if (impl_->cfg.enableBatchRenderer) {
+    //     impl_->renderMgr->batchRender();
+    // }
 }
 
 void Manager::setMaps(const std::vector<std::string> &maps)

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -585,14 +585,6 @@ void Manager::reset(std::vector<int32_t> worldsToReset) {
     }
 
     impl_->reset();
-
-    // if (impl_->renderMgr.has_value()) {
-    //     impl_->renderMgr->readECS();
-    // }
-
-    // if (impl_->cfg.enableBatchRenderer) {
-    //     impl_->renderMgr->batchRender();
-    // }
 }
 
 void Manager::setMaps(const std::vector<std::string> &maps)

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -763,7 +763,7 @@ void setupRestOfTasks(TaskGraphBuilder &builder, const Sim::Config &cfg,
         {clear_tmp});
 
     if (cfg.renderBridge) {
-        RenderingSystem::setupTasks(builder, {done_sys});
+        RenderingSystem::setupTasks(builder, dependencies);
     }
 
     TaskGraphNodeID lidar;

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -67,13 +67,13 @@ int main(int argc, char *argv[])
 #endif
 
     WindowManager wm {};
-    WindowHandle window = wm.makeWindow("Escape Room", 640, 480);
+    WindowHandle window = wm.makeWindow("Escape Room", 1920, 1080);
     render::GPUHandle render_gpu = wm.initGPU(0, { window.get() });
 
     Manager mgr({
         .execMode = exec_mode,
         .gpuID = 0,
-        .scenes = {"testJsons/test.json"},
+        .scenes = {"../data/processed/examples/tfrecord-00001-of-01000_307.json"},
         .params = {
             .polylineReductionThreshold = 1.0,
             .observationRadius = 100.0,
@@ -84,12 +84,13 @@ int main(int argc, char *argv[])
         .extRenderDev = render_gpu.device(),
     });
 
+    madrona::CountT stepCtr = 0;
     // math::Quat initial_camera_rotation = math::Quat::angleAxis(0, math::up).normalize();
     math::Quat initial_camera_rotation =
             (math::Quat::angleAxis(0, math::up) *
             math::Quat::angleAxis(-math::pi / 2.f, math::right)).normalize();
 
-        Viewer viewer(mgr.getRenderManager(), window.get(), {
+    Viewer viewer(mgr.getRenderManager(), window.get(), {
         .numWorlds = num_worlds,
         .simTickRate = 20,
         .cameraMoveSpeed = 20.f,
@@ -152,7 +153,12 @@ int main(int argc, char *argv[])
     };
 
     viewer.loop(
-    [](CountT world_idx, const Viewer::UserInput &input) {
+    [&mgr](CountT world_idx, const Viewer::UserInput &input) {
+
+        using Key = Viewer::KeyboardKey;
+        if (input.keyHit(Key::R)) {
+            mgr.reset({(int)world_idx});
+        }
         (void)world_idx;
     },
     [&mgr](CountT world_idx, CountT agent_idx,
@@ -164,10 +170,6 @@ int main(int argc, char *argv[])
 
         float acceleration{0};
         const float accelerationDelta{1};
-
-        if (input.keyPressed(Key::R)) {
-            mgr.triggerReset(world_idx);
-        }
 
         bool shift_pressed = input.keyPressed(Key::Shift);
 
@@ -197,7 +199,12 @@ int main(int argc, char *argv[])
         }
 
         mgr.step();
-        
-        printObs();
+        stepCtr++;
+
+        if(stepCtr % consts::episodeLen == 0) {
+            mgr.reset({0});
+        }
+
+        // printObs();
     }, []() {});
 }

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 #endif
 
     WindowManager wm {};
-    WindowHandle window = wm.makeWindow("Escape Room", 1920, 1080);
+    WindowHandle window = wm.makeWindow("GPUDrive", 1920, 1080);
     render::GPUHandle render_gpu = wm.initGPU(0, { window.get() });
 
     Manager mgr({


### PR DESCRIPTION
This PR aims to make viewer working again. It will help visualizing the 3D changes that are inbound. It does the following - 

1) Makes the madrona viewer working again. It was broken since previous updates to the taskgraph and madrona upstream changes.
2) Adds in "autoreset" on a viewer level. 
3) Also add in the ability to reset when you press R on the keyboard.

BUG - I am unable to completely manipulate the viewer on MacOS (like panning and zooming). I think this maybe a Mac specific bug. If this works on Linux, we should merge it in for now and revert back later to fix it for Mac. 

I was however able to test that the viewer and auto reset is working. 