### PR TITLE
Make collision behavior transient

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -298,6 +298,8 @@ inline void movementSystem(Engine &e,
                 // Reset collision state at the start of each timestep.
                 // This ensures the collision state is only true if the agent collided in the current timestep.
                 collisionEvent.hasCollided.store_relaxed(0); // Reset the collision state.
+                Info& info = e.get<Info>(agent_iface.e);
+                info.collidedWithRoad = info.collidedWithVehicle = info.collidedWithNonVehicle = 0;
                 break;
         }
     }


### PR DESCRIPTION
### Description

It looks like the current collision behavior is **persistent**, meaning once an agent collides, it remains in a collided state for the rest of the episode (until `sim.reset()` is called). If agents are penalized for collisions and the `collision behavior = 'ignore'`, this creates unintended effects for learning, as it becomes difficult to assign credit to the specific state that was "bad".

This PR aims to make the collision behavior **transient**, resetting the collision state at the start of each timestep. This ensures that the indicator function for collision in the info tensor is only true if the agent collided at the current timestep. The info tensor is used to define rewards as a linear combination of the collision, off_road and goal achieved metrics.
