### PR TITLE
Delete agents by agent id

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -127,7 +127,20 @@ namespace gpudrive
             .def("expert_trajectory_tensor", &Manager::expertTrajectoryTensor)
             .def("set_maps", &Manager::setMaps)
             .def("world_means_tensor", &Manager::worldMeansTensor)
-            .def("metadata_tensor", &Manager::metadataTensor);
+            .def("metadata_tensor", &Manager::metadataTensor)
+            .def("deleteAgents", [](Manager &self, nb::dict py_agents_to_delete) {
+                std::unordered_map<int32_t, std::vector<int32_t>> agents_to_delete;
+
+                // Convert Python dict to C++ unordered_map
+                for (auto item : py_agents_to_delete) {
+                    int32_t key = nb::cast<int32_t>(item.first);
+                    std::vector<int32_t> value = nb::cast<std::vector<int32_t>>(item.second);
+                    agents_to_delete[key] = value;
+                }
+
+                self.deleteAgents(agents_to_delete);
+            })
+            .def("deleted_agents_tensor", &Manager::deletedAgentsTensor);
     }
 
 }

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -347,6 +347,15 @@ static inline bool shouldAgentBeCreated(Engine &ctx, const MapObject &agentInit)
         return false;
     }
 
+    auto& deletedAgents = ctx.singleton<DeletedAgents>().deletedAgents;
+    for (CountT i = 0; i < consts::kMaxAgentCount; i++)
+    {
+        if(deletedAgents[i] == agentInit.id)
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -78,6 +78,9 @@ public:
                               float acceleration, float steering,
                               float headAngle);
     MGR_EXPORT void setMaps(const std::vector<std::string> &maps);
+
+    MGR_EXPORT void setToDelete(const std::unordered_map<int32_t, std::vector<int32_t>> &agentsToDelete);
+  
     // TODO: remove parameters
     MGR_EXPORT std::vector<Shape>
     getShapeTensorFromDeviceMemory();

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -69,6 +69,7 @@ public:
     MGR_EXPORT madrona::py::Tensor expertTrajectoryTensor() const;
     MGR_EXPORT madrona::py::Tensor worldMeansTensor() const;
     MGR_EXPORT madrona::py::Tensor metadataTensor() const;
+    MGR_EXPORT madrona::py::Tensor deletedAgentsTensor() const;
     madrona::py::Tensor rgbTensor() const;
     madrona::py::Tensor depthTensor() const;
     // These functions are used by the viewer to control the simulation
@@ -79,7 +80,7 @@ public:
                               float headAngle);
     MGR_EXPORT void setMaps(const std::vector<std::string> &maps);
 
-    MGR_EXPORT void setToDelete(const std::unordered_map<int32_t, std::vector<int32_t>> &agentsToDelete);
+    MGR_EXPORT void deleteAgents(const std::unordered_map<int32_t, std::vector<int32_t>> &agentsToDelete);
   
     // TODO: remove parameters
     MGR_EXPORT std::vector<Shape>

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -74,6 +74,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<Map>((uint32_t)ExportID::Map);
     registry.exportSingleton<ResetMap>((uint32_t)ExportID::ResetMap);
     registry.exportSingleton<WorldMeans>((uint32_t)ExportID::WorldMeans);
+    registry.exportSingleton<DeleteAgents>((uint32_t)ExportID::DeleteAgents);
     
     registry.exportColumn<AgentInterface, Action>(
         (uint32_t)ExportID::Action);

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -882,6 +882,11 @@ Sim::Sim(Engine &ctx,
 
     auto& map = ctx.singleton<Map>();
     map = *(init.map);
+
+    auto& deletedAgents = ctx.singleton<DeletedAgents>();
+    for (auto i = 0; i < consts::kMaxAgentCount; i++) {
+        deletedAgents.deletedAgents[i] = -1;
+    }
     // Creates agents, walls, etc.
     createPersistentEntities(ctx);
 

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -62,6 +62,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerSingleton<Map>();
     registry.registerSingleton<ResetMap>();
     registry.registerSingleton<WorldMeans>();
+    registry.registerSingleton<DeletedAgents>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
@@ -74,7 +75,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<Map>((uint32_t)ExportID::Map);
     registry.exportSingleton<ResetMap>((uint32_t)ExportID::ResetMap);
     registry.exportSingleton<WorldMeans>((uint32_t)ExportID::WorldMeans);
-    registry.exportSingleton<DeleteAgents>((uint32_t)ExportID::DeleteAgents);
+    registry.exportSingleton<DeletedAgents>((uint32_t)ExportID::DeletedAgents);
     
     registry.exportColumn<AgentInterface, Action>(
         (uint32_t)ExportID::Action);

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -37,7 +37,7 @@ enum class ExportID : uint32_t {
     ResetMap,
     WorldMeans,
     MetaData,
-    DeleteAgents,
+    DeletedAgents,
     NumExports
 };
 

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -37,6 +37,7 @@ enum class ExportID : uint32_t {
     ResetMap,
     WorldMeans,
     MetaData,
+    DeleteAgents,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -94,6 +94,10 @@ namespace gpudrive
         int32_t reset;
     };   
 
+    struct DeleteAgents {
+        int32_t deleteAgents[consts::kMaxAgentCount];
+    };
+
     struct WorldMeans {
         madrona::math::Vector3 mean; // TODO: Z is 0 for now, but can be used for 3D in future
     };

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -94,8 +94,8 @@ namespace gpudrive
         int32_t reset;
     };   
 
-    struct DeleteAgents {
-        int32_t deleteAgents[consts::kMaxAgentCount];
+    struct DeletedAgents {
+        int32_t deletedAgents[consts::kMaxAgentCount];
     };
 
     struct WorldMeans {


### PR DESCRIPTION
This PR introduces feature to delete agents by their agent id. 

To use this feature, you can call `sim.deleteAgents(world_to_agent_dict)`. The dict structure is `{world_idx: [agent_ids]}`. Sample code:

```
sim.deleteAgents({0: [1408]}) # delete agent id 1408 in world idx 0
```

We set an array `deletedAgents` with agent ids. We reuse functionality of `setMaps` where we destroy all agents and reinitialize them. But we ignore the agents specified in `deletedAgents`. So the agents are not initialized. Remember, because of this the indexing will change. For eg an agent at idx 5 will be at idx 4 after an agent is deleted. 

Also, the `deletedAgents` array is permanent. You can reset this tensor with -1 values to reinitialize all the agents again. However, I reset the `deletedAgents` array when you call `setMaps` to change the map on runtime because the agent ids will have changed. 