### PR TITLE
Add plot expert trajectories

### DIFF
--- a/pygpudrive/env/config.py
+++ b/pygpudrive/env/config.py
@@ -182,7 +182,7 @@ class RenderConfig:
         line_thickness (int): Thickness of the road lines in the rendering.
         draw_obj_idx (bool): Whether to draw object indices on objects.
         draw_expert_trajectories (bool): Whether to draw expert trajectories.
-        draw_only_ego_expert_traj (bool): Whether to draw only the ego expert trajectory.
+        draw_only_controllable_veh (bool): Whether to draw only the trajectories of controllable vehicles.
         obj_idx_font_size (int): Font size for object indices.
         color_scheme (str): Color mode for the rendering ("light" or "dark").
     """
@@ -193,7 +193,7 @@ class RenderConfig:
     line_thickness: int = 0.7
     draw_obj_idx: bool = False
     draw_expert_trajectories: bool = False
-    draw_only_ego_expert_traj: bool = False
+    draw_only_controllable_veh: bool = False
     obj_idx_font_size: int = 9
     color_scheme: str = "light"
 

--- a/pygpudrive/env/config.py
+++ b/pygpudrive/env/config.py
@@ -181,6 +181,8 @@ class RenderConfig:
         resolution (Tuple[int, int]): Resolution of the rendered image.
         line_thickness (int): Thickness of the road lines in the rendering.
         draw_obj_idx (bool): Whether to draw object indices on objects.
+        draw_expert_trajectories (bool): Whether to draw expert trajectories.
+        draw_only_ego_expert_traj (bool): Whether to draw only the ego expert trajectory.
         obj_idx_font_size (int): Font size for object indices.
         color_scheme (str): Color mode for the rendering ("light" or "dark").
     """
@@ -190,6 +192,8 @@ class RenderConfig:
     resolution: Tuple[int, int] = (1024, 1024)
     line_thickness: int = 0.7
     draw_obj_idx: bool = False
+    draw_expert_trajectories: bool = False
+    draw_only_ego_expert_traj: bool = False
     obj_idx_font_size: int = 9
     color_scheme: str = "light"
 

--- a/pygpudrive/env/env_torch.py
+++ b/pygpudrive/env/env_torch.py
@@ -501,7 +501,7 @@ if __name__ == "__main__":
     scene_config = SceneConfig("data/processed/examples", NUM_WORLDS)
     render_config = RenderConfig(
         draw_expert_trajectories=True,
-        draw_only_ego_expert_traj=True,
+        draw_only_controllable_veh=True,
     )
 
     # MAKE ENV

--- a/pygpudrive/visualize/core.py
+++ b/pygpudrive/visualize/core.py
@@ -526,7 +526,7 @@ class MatplotlibVisualizer:
             non_controlled_mask = ~response_type.static[env_idx, :] & response_type.moving[env_idx, :] & ~controlled_mask
             mask = (
                 controlled_mask
-                if self.vis_config.draw_only_ego_expert_traj
+                if self.vis_config.draw_only_controllable_veh
                 else controlled_mask | non_controlled_mask
             )
             agent_indices = torch.where(mask)[0]

--- a/pygpudrive/visualize/core.py
+++ b/pygpudrive/visualize/core.py
@@ -17,6 +17,7 @@ from pygpudrive.datatypes.observation import (
     GlobalEgoState,
     PartnerObs,
 )
+from pygpudrive.datatypes.trajectory import LogTrajectory
 from pygpudrive.datatypes.control import ResponseType
 from pygpudrive.visualize.color import (
     ROAD_GRAPH_COLORS,
@@ -94,6 +95,13 @@ class MatplotlibVisualizer:
             backend=self.backend,
             device=self.device,
         )
+        log_trajectory = LogTrajectory.from_tensor(
+            expert_traj_tensor=self.sim_object.expert_trajectory_tensor(),
+            num_worlds=len(env_indices),
+            max_agents=self.controlled_agents.shape[1],
+            backend=self.backend,
+        )
+        expert_trajectories = log_trajectory.pos_xy.to(self.device)
 
         agent_infos = self.sim_object.info_tensor().to_torch().to(self.device)
 
@@ -156,6 +164,14 @@ class MatplotlibVisualizer:
                 ax=ax,
                 line_width_scale=line_width_scale,
                 marker_size_scale=marker_scale,
+            )
+
+            # Draw expert trajectories
+            self._plot_expert_trajectories(
+                ax=ax,
+                env_idx=env_idx,
+                expert_trajectories=expert_trajectories,
+                response_type=response_type,
             )
 
             # Draw the agents
@@ -491,6 +507,44 @@ class MatplotlibVisualizer:
             as_center_pts=as_center_pts,
             label=label,
         )
+
+    def _plot_expert_trajectories(
+        self,
+        ax: matplotlib.axes.Axes,
+        env_idx: int,
+        expert_trajectories: torch.Tensor,
+        response_type: Any,
+    ) -> None:
+        """Plot expert trajectories.
+        Args:
+            ax: Matplotlib axis for plotting.
+            env_idx: Environment index to select specific environment agents.
+            expert_trajectories: The global state of expert from `LogTrajectory`.
+        """
+        if self.vis_config.draw_expert_trajectories:
+            controlled_mask = self.controlled_agents[env_idx, :]
+            non_controlled_mask = ~response_type.static[env_idx, :] & response_type.moving[env_idx, :] & ~controlled_mask
+            mask = (
+                controlled_mask
+                if self.vis_config.draw_only_ego_expert_traj
+                else controlled_mask | non_controlled_mask
+            )
+            agent_indices = torch.where(mask)[0]
+            trajectories = expert_trajectories[env_idx][mask]
+            for idx, trajectory in zip(agent_indices, trajectories):
+                color = AGENT_COLOR_BY_STATE["ok"] if controlled_mask[idx] else AGENT_COLOR_BY_STATE["log_replay"]
+                for step in trajectory:
+                    x, y = step[:2].numpy()
+                    if x < OUT_OF_BOUNDS and y < OUT_OF_BOUNDS:
+                        ax.add_patch(
+                            Circle(
+                                (x, y),
+                                radius=0.3,
+                                color=color,
+                                fill=True,
+                                alpha=0.5,
+                            )
+                        )
 
     def plot_agent_observation(
         self,


### PR DESCRIPTION
### Description
This PR adds an option to visualize expert trajectories.
This option can be turned on/off with two booleans:

`draw_expert_trajectories` 
: A boolean indicating whether to draw expert trajectories.
`draw_only_ego_expert_traj`:
: A boolean indicating whether to draw only ego trajectories (only effective if `draw_expert_trajectories` is True)

### Behavior
`draw_expert_trajectories=False`, `draw_only_ego_expert_traj=True/False`
![1](https://github.com/user-attachments/assets/fe6b3601-10ba-421f-91a9-3bdc1030150d)

`draw_expert_trajectories=True`,  `draw_only_ego_expert_traj=False`
![2](https://github.com/user-attachments/assets/38b6f280-8d83-4832-b0e0-c2dda0f2a740)

`draw_expert_trajectories=True`,  `draw_only_ego_expert_traj=True`
![3](https://github.com/user-attachments/assets/3859562a-8370-44d1-9461-5c5d71e05560)