### PR TITLE
Scenario id as attribute of `SimManager` class

### DIFF
--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -713,10 +713,6 @@ if __name__ == "__main__":
         max_cont_agents=64,  # Number of agents to control
         device="cpu",
     )
-    
-    
-    test = env.get_scenario_ids()
-
 
     control_mask = env.cont_agent_mask
 

--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -677,6 +677,20 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
             filenames[i] = map_name
 
         return filenames
+    
+    def get_scenario_ids(self):
+        """Obtain the scenario ID for each world."""
+        scenario_id_integers = self.sim.scenario_id_tensor().to_torch()
+        scenario_ids = {}
+        
+        # Iterate through the number of worlds
+        for i in range(self.num_worlds):
+            tensor = scenario_id_integers[i]
+            # Convert ints to characters, ignoring zeros
+            scenario_id = "".join([chr(i) for i in tensor.tolist() if i != 0])
+            scenario_ids[i] = scenario_id
+        
+        return scenario_ids
 
 
 if __name__ == "__main__":
@@ -699,6 +713,10 @@ if __name__ == "__main__":
         max_cont_agents=64,  # Number of agents to control
         device="cpu",
     )
+    
+    
+    test = env.get_scenario_ids()
+
 
     control_mask = env.cont_agent_mask
 

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -129,7 +129,6 @@ namespace madrona_gpudrive
             .def("world_means_tensor", &Manager::worldMeansTensor)
             .def("metadata_tensor", &Manager::metadataTensor)
             .def("map_name_tensor", &Manager::mapNameTensor)
-            .def("scenario_id_tensor", &Manager::scenarioIdTensor)
             .def("deleteAgents", [](Manager &self, nb::dict py_agents_to_delete) {
                 std::unordered_map<int32_t, std::vector<int32_t>> agents_to_delete;
 

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -129,6 +129,7 @@ namespace madrona_gpudrive
             .def("world_means_tensor", &Manager::worldMeansTensor)
             .def("metadata_tensor", &Manager::metadataTensor)
             .def("map_name_tensor", &Manager::mapNameTensor)
+            .def("scenario_id_tensor", &Manager::scenarioIdTensor)
             .def("deleteAgents", [](Manager &self, nb::dict py_agents_to_delete) {
                 std::unordered_map<int32_t, std::vector<int32_t>> agents_to_delete;
 
@@ -142,7 +143,8 @@ namespace madrona_gpudrive
                 self.deleteAgents(agents_to_delete);
             })
             .def("deleted_agents_tensor", &Manager::deletedAgentsTensor)
-            .def("map_name_tensor", &Manager::mapNameTensor);
+            .def("map_name_tensor", &Manager::mapNameTensor)
+            .def("scenario_id_tensor", &Manager::scenarioIdTensor);
     }
 
 }

--- a/src/init.hpp
+++ b/src/init.hpp
@@ -62,6 +62,8 @@ namespace madrona_gpudrive
 
         char mapName[32];
 
+        char scenarioId[32];
+
         // Constructor
         Map() = default;
     };

--- a/src/json_serialization.hpp
+++ b/src/json_serialization.hpp
@@ -282,6 +282,9 @@ namespace madrona_gpudrive
         std::string name = j.at("name").get<std::string>();
         std::strncpy(map.mapName, name.c_str(), sizeof(map.mapName));
 
+        std::string scenario_id = j.at("scenario_id").get<std::string>();
+        std::strncpy(map.scenarioId, scenario_id.c_str(), sizeof(map.scenarioId));
+    
         auto mean = calc_mean(j);
         map.mean = {mean.first, mean.second};
         map.numObjects = std::min(j.at("objects").size(), static_cast<size_t>(MAX_OBJECTS));

--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -368,6 +368,10 @@ void createPersistentEntities(Engine &ctx) {
         mapName.mapName[i] = map.mapName[i];
     }
 
+    auto& scenarioId = ctx.singleton<ScenarioId>();
+    for (int i = 0; i < 32; i++) {
+        scenarioId.scenarioId[i] = map.scenarioId[i]; 
+    }
 
     if (ctx.data().enableRender)
     {

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -875,6 +875,13 @@ Tensor Manager::mapNameTensor() const {
     );
 }
 
+Tensor Manager::scenarioIdTensor() const {
+    return impl_->exportTensor(
+        ExportID::ScenarioId, TensorElementType::Int32,
+        {impl_->numWorlds, ScenarioIdExportSize}
+    );
+}
+
 Tensor Manager::metadataTensor() const {
     return impl_->exportTensor(
         ExportID::MetaData, TensorElementType::Int32,

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -71,6 +71,7 @@ public:
     MGR_EXPORT madrona::py::Tensor metadataTensor() const;
     MGR_EXPORT madrona::py::Tensor deletedAgentsTensor() const;
     MGR_EXPORT madrona::py::Tensor mapNameTensor() const;
+    MGR_EXPORT madrona::py::Tensor scenarioIdTensor() const;
     madrona::py::Tensor rgbTensor() const;
     madrona::py::Tensor depthTensor() const;
     // These functions are used by the viewer to control the simulation

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -64,6 +64,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.registerSingleton<WorldMeans>();
     registry.registerSingleton<DeletedAgents>();
     registry.registerSingleton<MapName>();
+    registry.registerSingleton<ScenarioId>();
 
     registry.registerArchetype<Agent>();
     registry.registerArchetype<PhysicsEntity>();
@@ -78,6 +79,7 @@ void Sim::registerTypes(ECSRegistry &registry, const Config &cfg)
     registry.exportSingleton<WorldMeans>((uint32_t)ExportID::WorldMeans);
     registry.exportSingleton<DeletedAgents>((uint32_t)ExportID::DeletedAgents);
     registry.exportSingleton<MapName>((uint32_t)ExportID::MapName);
+    registry.exportSingleton<ScenarioId>((uint32_t)ExportID::ScenarioId);
     
     registry.exportColumn<AgentInterface, Action>(
         (uint32_t)ExportID::Action);

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -39,6 +39,7 @@ enum class ExportID : uint32_t {
     MetaData,
     DeletedAgents,
     MapName,
+    ScenarioId,
     NumExports
 };
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -389,6 +389,14 @@ namespace madrona_gpudrive
     const size_t MapNameExportSize = 32;
     static_assert(sizeof(MapName) == sizeof(char32_t) * MapNameExportSize);
 
+    struct ScenarioId
+    {
+        char32_t scenarioId[32];
+    };
+
+    const size_t ScenarioIdExportSize = 32;
+    static_assert(sizeof(ScenarioId) == sizeof(char32_t) * ScenarioIdExportSize);
+
     //Metadata struct : using agent IDs.
     struct MetaData
     {


### PR DESCRIPTION
### Description

The goal of this PR is to add the hex `scenario_id` from the json files as attribute in the SimManager class.

### Problem

It looks like the `scenario_id_tensor()` is not being registered.

```Python
Exception has occurred: AttributeError
'SimManager' object has no attribute 'scenario_id_tensor'
  File "/home/emerge/gpudrive/gpudrive/env/env_torch.py", line 683, in get_scenario_ids
    scenario_id_integers = self.sim.scenario_id_tensor().to_torch()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emerge/gpudrive/gpudrive/env/env_torch.py", line 718, in <module>
    test = env.get_scenario_ids()
           ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SimManager' object has no attribute 'scenario_id_tensor'
```