### PR TITLE
Agent behavior diversity through reward conditioning

### DIFF
--- a/baselines/ppo/ppo_pufferlib.py
+++ b/baselines/ppo/ppo_pufferlib.py
@@ -48,7 +48,7 @@ def load_config(config_path):
 
 def make_agent(env, config):
     """Create a policy based on the environment."""
-    
+
     if config.continue_training:
         print("Loading checkpoint...")
         # Load checkpoint
@@ -61,14 +61,14 @@ def make_agent(env, config):
             input_dim=saved_cpt["model_arch"]["input_dim"],
             action_dim=saved_cpt["action_dim"],
             hidden_dim=saved_cpt["model_arch"]["hidden_dim"],
-            reward_type=config.environment.reward_type
+            config=config.environment,
         )
 
         # Load the model parameters
         policy.load_state_dict(saved_cpt["parameters"])
-        
+
         return policy
-        
+
     else:
         # Start from scratch
         return NeuralNet(
@@ -76,8 +76,9 @@ def make_agent(env, config):
             action_dim=env.single_action_space.n,
             hidden_dim=config.train.network.hidden_dim,
             dropout=config.train.network.dropout,
-            reward_type= config.environment.reward_type
+            config=config.environment,
         )
+
 
 def train(args, vecenv):
     """Main training loop for the PPO agent."""
@@ -245,11 +246,11 @@ def run(
     )
 
     datetime_ = datetime.now().strftime("%m_%d_%H_%M_%S_%f")[:-3]
-    
+
     if config["continue_training"]:
-        cont_train = 'C'
+        cont_train = "C"
     else:
-        cont_train = ''
+        cont_train = ""
 
     if config["train"]["resample_scenes"]:
         if config["train"]["resample_scenes"]:

--- a/baselines/ppo/ppo_pufferlib.py
+++ b/baselines/ppo/ppo_pufferlib.py
@@ -61,6 +61,7 @@ def make_agent(env, config):
             input_dim=saved_cpt["model_arch"]["input_dim"],
             action_dim=saved_cpt["action_dim"],
             hidden_dim=saved_cpt["model_arch"]["hidden_dim"],
+            reward_type=config.environment.reward_type
         )
 
         # Load the model parameters
@@ -75,6 +76,7 @@ def make_agent(env, config):
             action_dim=env.single_action_space.n,
             hidden_dim=config.train.network.hidden_dim,
             dropout=config.train.network.dropout,
+            reward_type= config.environment.reward_type
         )
 
 def train(args, vecenv):

--- a/examples/tutorials/07_agent_behavior_diversity.md
+++ b/examples/tutorials/07_agent_behavior_diversity.md
@@ -1,0 +1,120 @@
+# Agent behavior diversity through reward conditioning
+
+## Introduction
+
+This tutorial explains how to use reward conditioning to create diverse agent behaviors in the GPUDrive environment. Inspired by [Robust autonomy emerges from self-play](https://arxiv.org/abs/2502.03349) (Appendix B.3), we condition agents on different reward weights to produce a spectrum of behaviors ranging from cautious to aggressive, all using a single policy network.
+
+## Setting up the environment
+
+First, let's set up the GPUDrive environment:
+
+```python
+from gpudrive.env.config import EnvConfig, RenderConfig
+from gpudrive.env.dataset import SceneDataLoader
+from gpudrive.env.torch_env import GPUDriveTorchEnv
+
+# Create environment config
+env_config = EnvConfig(
+    # Change this to "reward_conditioned" to enable reward conditioning
+    reward_type="reward_conditioned",
+
+    # Add reward bounds for each component
+    collision_weight_lb=-1.0,
+    collision_weight_ub=-0.1,
+    goal_achieved_weight_lb=0.5,
+    goal_achieved_weight_ub=2.0,
+    off_road_weight_lb=-1.0,
+    off_road_weight_ub=-0.1,
+
+    # Default conditioning mode
+    condition_mode="random"
+)
+
+render_config = RenderConfig()
+
+# Create data loader
+train_loader = SceneDataLoader(
+    root="data/processed/examples",
+    batch_size=2,
+    dataset_size=100,
+    sample_with_replacement=True,
+    shuffle=False,
+)
+
+# Create environment
+env = GPUDriveTorchEnv(
+    config=env_config,
+    data_loader=train_loader,
+    max_cont_agents=64,  # Number of agents to control
+    device="cuda",  # Use GPU if available
+)
+
+# Get controlled agent mask
+control_mask = env.cont_agent_mask
+
+# Reset the environment
+obs = env.reset()
+```
+
+To enable reward conditioning, set `reward_type="reward_conditioned"` in the environment config.
+
+## Conditioning Modes
+
+We currently support three conditioning modes:
+
+1. **Random mode**: Each agent receives random reward weights within the specified bounds
+2. **Preset mode**: Agents use predefined behavior profiles (cautious, aggressive, etc.)
+3. **Fixed mode**: Custom reward weights are provided directly
+
+### 1. Random mode (default for training)
+
+During training, you'll typically use random mode to create a diverse set of agent behaviors:
+
+```python
+# Random mode is the default, but you can explicitly set it
+obs = env.reset(condition_mode="random")
+
+# Alternatively, set it in the config
+env_config.condition_mode = "random"
+env = GPUDriveTorchEnv(config=env_config, data_loader=train_loader, max_cont_agents=64)
+```
+
+In random mode, each agent receives unique reward weights sampled uniformly within the bounds specified in the config. This creates a diverse population of agents with different behaviors, enabling the policy to learn to handle a wide range of scenarios.
+
+### 2. Preset mode (particular agent profiles)
+
+For testing or evaluation, you might want consistent behavior patterns. Preset mode provides predefined agent personalities:
+
+```python
+# All agents use the cautious behavior profile
+obs = env.reset(condition_mode="preset", agent_type="cautious")
+
+# Available preset types:
+# - "cautious": Strong penalties for risk, moderate goal reward
+# - "aggressive": Lower penalties, higher goal reward
+# - "balanced": Middle ground between cautious and aggressive
+# - "risk_taker": Minimal penalties, maximum goal reward
+```
+
+This is useful for evaluating policy performance under specific conditions or for demonstrations.
+
+### 3. Fixed mode (for custom behaviors)
+
+For complete control over agent behavior, you can specify exact reward weights:
+
+```python
+# Define custom weights [collision, goal, off_road]
+custom_weights = torch.tensor([-0.75, 1.5, -0.3])
+obs = env.reset(condition_mode="fixed", agent_type=custom_weights)
+```
+
+This gives you precise control over agent behavior for specific testing scenarios.
+
+
+## Incorporating rewards into the observation
+
+For the policy to adapt its behavior based on reward conditioning, the reward weights should be included in the agent's observation. This allows the policy to "know" it's type. By default, if `reward_type == 'reward_conditioned'`, the weights for each of the 3 reward components are added to the `ego_state`.
+
+## Conclusion
+
+Reward conditioning is a simple but powerful technique for creating diverse agent behaviors in simulation. By conditioning agents on different reward weights, we can create a spectrum of behaviors from a single policy, resulting in more realistic and varied simulations. We showed how you can get started with this with `gpudrive`.

--- a/examples/tutorials/07_agent_behavior_diversity.md
+++ b/examples/tutorials/07_agent_behavior_diversity.md
@@ -117,4 +117,4 @@ For the policy to adapt its behavior based on reward conditioning, the reward we
 
 ## Conclusion
 
-Reward conditioning is a simple but powerful technique for creating diverse agent behaviors in simulation. By conditioning agents on different reward weights, we can create a spectrum of behaviors from a single policy, resulting in more realistic and varied simulations. We showed how you can get started with this with `gpudrive`.
+Reward conditioning is a simple but powerful technique for creating diverse agent behaviors in simulation. By conditioning agents on different reward weights, we can create a spectrum of behaviors from a single policy, resulting in more varied simulations. We showed how you can get started with reward conditioning in `gpudrive`.

--- a/gpudrive/env/base_env.py
+++ b/gpudrive/env/base_env.py
@@ -62,6 +62,7 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
             self.config.reward_type == "sparse_on_goal_achieved"
             or self.config.reward_type == "weighted_combination"
             or self.config.reward_type == "distance_to_logs"
+            or self.config.reward_type == "random_weighted_combination"
         ):
             reward_params.rewardType = madrona_gpudrive.RewardType.OnGoalAchieved
         else:

--- a/gpudrive/env/base_env.py
+++ b/gpudrive/env/base_env.py
@@ -62,7 +62,7 @@ class GPUDriveGymEnv(gym.Env, metaclass=abc.ABCMeta):
             self.config.reward_type == "sparse_on_goal_achieved"
             or self.config.reward_type == "weighted_combination"
             or self.config.reward_type == "distance_to_logs"
-            or self.config.reward_type == "random_weighted_combination"
+            or self.config.reward_type == "reward_conditioned"
         ):
             reward_params.rewardType = madrona_gpudrive.RewardType.OnGoalAchieved
         else:

--- a/gpudrive/env/config.py
+++ b/gpudrive/env/config.py
@@ -94,8 +94,10 @@ class EnvConfig:
     remove_non_vehicles: bool = True  # Remove non-vehicle entities from scene
 
     # Reward settings
-    reward_type: str = "sparse_on_goal_achieved"  
+    reward_type: str = "sparse_on_goal_achieved"
     # Alternatively, "weighted_combination", "distance_to_logs", "reward_conditioned"
+
+    condition_mode: str = "random"  # Options: "random", "fixed", "preset"
 
     # Define upper and lower bounds for reward components if using reward_conditioned
     collision_weight_lb: float = -1.0
@@ -169,10 +171,13 @@ class RenderMode(Enum):
     MADRONA_RGB = "madrona_rgb"
     MADRONA_DEPTH = "madrona_depth"
 
+
 class MadronaOption(Enum):
     """Enum for Madrona rendering options."""
+
     AGENT_VIEW = "agent_view"
     TOP_DOWN = "top_down"
+
 
 @dataclass
 class RenderConfig:

--- a/gpudrive/env/config.py
+++ b/gpudrive/env/config.py
@@ -94,7 +94,16 @@ class EnvConfig:
     remove_non_vehicles: bool = True  # Remove non-vehicle entities from scene
 
     # Reward settings
-    reward_type: str = "sparse_on_goal_achieved"  # Alternatively, "weighted_combination", "distance_to_logs"
+    reward_type: str = "sparse_on_goal_achieved"  
+    # Alternatively, "weighted_combination", "distance_to_logs", "random_weighted_combination"
+
+    # Define upper and lower bounds for reward components if using random_weighted_combination
+    collision_weight_lb: float = -1.0
+    collision_weight_ub: float = 0.0
+    goal_achieved_weight_lb: float = 1.0
+    goal_achieved_weight_ub: float = 2.0
+    off_road_weight_lb: float = -1.0
+    off_road_weight_ub: float = 0.0
 
     dist_to_goal_threshold: float = (
         2.0  # Radius around goal considered as "goal achieved"

--- a/gpudrive/env/config.py
+++ b/gpudrive/env/config.py
@@ -95,9 +95,9 @@ class EnvConfig:
 
     # Reward settings
     reward_type: str = "sparse_on_goal_achieved"  
-    # Alternatively, "weighted_combination", "distance_to_logs", "random_weighted_combination"
+    # Alternatively, "weighted_combination", "distance_to_logs", "reward_conditioned"
 
-    # Define upper and lower bounds for reward components if using random_weighted_combination
+    # Define upper and lower bounds for reward components if using reward_conditioned
     collision_weight_lb: float = -1.0
     collision_weight_ub: float = 0.0
     goal_achieved_weight_lb: float = 1.0

--- a/gpudrive/env/env_puffer.py
+++ b/gpudrive/env/env_puffer.py
@@ -358,7 +358,7 @@ class PufferGPUDrive(PufferEnv):
             self.last_obs = self.env.get_obs(self.controlled_agent_mask)
 
             # Asynchronously reset the done worlds and empty storage
-            self.env.sim.reset(done_worlds_cpu)
+            self.env.reset(env_idx_list=done_worlds_cpu)
             self.episode_returns[done_worlds] = 0
             self.agent_episode_returns[done_worlds, :] = 0
             self.episode_lengths[done_worlds, :] = 0

--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -153,6 +153,24 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
             return weighted_rewards
 
+        elif self.config.reward_type == "random_weighted_combination":
+            # Extract individual weight components from the tensor
+            # Shape: [num_worlds, max_agents, 3]
+            if self.reward_weights_tensor is None:
+                # Initialize if not already done (fallback, should rarely happen)
+                self._get_random_reward_weights()
+
+            # Apply the weights in a vectorized manner
+            # Each index in dimension 2 corresponds to a specific weight:
+            # 0: collision, 1: goal_achieved, 2: off_road
+            weighted_rewards = (
+                self.reward_weights_tensor[:, :, 0] * collided
+                + self.reward_weights_tensor[:, :, 1] * goal_achieved
+                + self.reward_weights_tensor[:, :, 2] * off_road
+            )
+
+            return weighted_rewards
+
         elif self.config.reward_type == "distance_to_logs":
             # Reward based on distance to logs and penalty for collision
 

--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -44,7 +44,15 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         self.device = device
         self.render_config = render_config
         self.backend = backend
-
+        
+        # Initialize reward weights tensor if using random_weighted_combination
+        self.reward_weights_tensor = None
+        if (
+            hasattr(self.config, "reward_type")
+            and self.config.reward_type == "random_weighted_combination"
+        ):
+            self._get_random_reward_weights()
+        
         # Environment parameter setup
         params = self._setup_environment_parameters()
 
@@ -83,7 +91,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
         self.num_agents = self.cont_agent_mask.sum().item()
         self.episode_len = self.config.episode_len
-
+        
         # Rendering setup
         self.vis = MatplotlibVisualizer(
             sim_object=self.sim,
@@ -94,10 +102,83 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
             render_config=self.render_config,
             env_config=self.config,
         )
+        
+    def _get_random_reward_weights(self, env_idx_list=None):
+        """Initialize random reward weights for all or specific environments.
 
-    def reset(self, mask=None):
+        Args:
+            env_idx_list: List of environment indices to generate new weights for.
+                        If None, all environments are updated.
+        """
+        if self.reward_weights_tensor is None:
+            self.reward_weights_tensor = torch.zeros(
+                self.num_worlds,
+                self.max_cont_agents,
+                3,  # collision, goal_achieved, off_road
+                device=self.device,
+            )
+
+        # Read bounds for the three reward components
+        lower_bounds = torch.tensor(
+            [
+                self.config.collision_weight_lb,
+                self.config.goal_achieved_weight_lb,
+                self.config.off_road_weight_lb,
+            ],
+            device=self.device,
+        )
+
+        upper_bounds = torch.tensor(
+            [
+                self.config.collision_weight_ub,
+                self.config.goal_achieved_weight_ub,
+                self.config.off_road_weight_ub,
+            ],
+            device=self.device,
+        )
+        bounds_range = upper_bounds - lower_bounds
+
+        if env_idx_list is None or len(env_idx_list) == self.num_worlds:
+            # Generate random values for all environments at once
+            random_values = torch.rand(
+                self.num_worlds, self.max_cont_agents, 3, device=self.device
+            )
+
+            # Scale to fit within bounds and update the tensor
+            self.reward_weights_tensor = (
+                lower_bounds + random_values * bounds_range
+            )
+        else:
+            # For specific environments, we update them individually
+            env_indices = torch.tensor(env_idx_list, device=self.device)
+
+            # Generate random values for all specified environments at once
+            random_values = torch.rand(
+                len(env_indices), self.max_cont_agents, 3, device=self.device
+            )
+
+            # Scale to fit within bounds
+            scaled_values = lower_bounds + random_values * bounds_range
+
+            # Update the specific environments
+            for i, env_idx in enumerate(env_indices):
+                self.reward_weights_tensor[env_idx] = scaled_values[i]
+
+    def reset(self, mask=None, env_idx_list=None):
         """Reset the worlds and return the initial observations."""
-        self.sim.reset(list(range(self.num_worlds)))
+        if env_idx_list is not None:  # Reset specific worlds
+            self.sim.reset(env_idx_list)
+        else:  # Reset all worlds
+            env_idx_list = list(range(self.num_worlds))
+            self.sim.reset(env_idx_list)
+
+        # Re-initialize random reward weights if using random_weighted_combination
+        if (
+            hasattr(self.config, "reward_type")
+            and self.config.reward_type == "random_weighted_combination"
+        ):
+            self._get_random_reward_weights(env_idx_list)
+
         return self.get_obs(mask)
 
     def get_dones(self):
@@ -132,19 +213,20 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
         The importance of each component is determined by the weights.
         """
+        
+        # Return the weighted combination of the reward components
+        info_tensor = self.sim.info_tensor().to_torch().clone()
+        off_road = info_tensor[:, :, 0].to(torch.float)
+
+        # True if the vehicle is in collision with another road object
+        # (i.e. a cyclist or pedestrian)
+        collided = info_tensor[:, :, 1:3].to(torch.float).sum(axis=2)
+        goal_achieved = info_tensor[:, :, 3].to(torch.float)
+        
         if self.config.reward_type == "sparse_on_goal_achieved":
             return self.sim.reward_tensor().to_torch().clone().squeeze(dim=2)
 
         elif self.config.reward_type == "weighted_combination":
-            # Return the weighted combination of the reward components
-            info_tensor = self.sim.info_tensor().to_torch().clone()
-            off_road = info_tensor[:, :, 0].to(torch.float)
-
-            # True if the vehicle is in collision with another road object
-            # (i.e. a cyclist or pedestrian)
-            collided = info_tensor[:, :, 1:3].to(torch.float).sum(axis=2)
-            goal_achieved = info_tensor[:, :, 3].to(torch.float)
-
             weighted_rewards = (
                 collision_weight * collided
                 + goal_achieved_weight * goal_achieved
@@ -158,7 +240,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
             # Shape: [num_worlds, max_agents, 3]
             if self.reward_weights_tensor is None:
                 # Initialize if not already done (fallback, should rarely happen)
-                self._get_random_reward_weights()
+                self._initialize_random_reward_weights()
 
             # Apply the weights in a vectorized manner
             # Each index in dimension 2 corresponds to a specific weight:
@@ -168,7 +250,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
                 + self.reward_weights_tensor[:, :, 1] * goal_achieved
                 + self.reward_weights_tensor[:, :, 2] * off_road
             )
-
+            
             return weighted_rewards
 
         elif self.config.reward_type == "distance_to_logs":
@@ -712,7 +794,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
 
 if __name__ == "__main__":
-    env_config = EnvConfig(dynamics_model="delta_local")
+    env_config = EnvConfig(reward_type="random_weighted_combination", dynamics_model="delta_local")
     render_config = RenderConfig()
 
     # Create data loader

--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -794,7 +794,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
 
 
 if __name__ == "__main__":
-    env_config = EnvConfig(reward_type="random_weighted_combination", dynamics_model="delta_local")
+    env_config = EnvConfig(reward_type="weighted_combination", dynamics_model="delta_local")
     render_config = RenderConfig()
 
     # Create data loader

--- a/gpudrive/networks/late_fusion.py
+++ b/gpudrive/networks/late_fusion.py
@@ -101,8 +101,10 @@ class NeuralNet(
         )
         if config is not None:
             self.config = config
-            if self.config.reward_type == "random_weighted_combination":
-                self.ego_state_idx += 3
+            if self.config.reward_type == "reward_conditioned":
+                # Agents know their "type", consisting of three weights
+                # that determine the reward (collision, goal, off-road)
+                self.ego_state_idx += 3 
                 self.partner_obs_idx += 3
 
         self.ego_embed = nn.Sequential(

--- a/gpudrive/networks/late_fusion.py
+++ b/gpudrive/networks/late_fusion.py
@@ -81,6 +81,7 @@ class NeuralNet(
         act_func="tanh",
         max_controlled_agents=64,
         obs_dim=2984, # Size of the flattened observation vector 
+        reward_type = "weighted_combination"
     ):
         super().__init__()
         self.input_dim = input_dim
@@ -96,10 +97,13 @@ class NeuralNet(
         # Indices for unpacking the observation
         self.ego_state_idx = constants.EGO_FEAT_DIM
         self.partner_obs_idx = constants.PARTNER_FEAT_DIM * self.max_controlled_agents
+        if reward_type == "random_weighted_combination":
+            self.ego_state_idx += 3
+            self.partner_obs_idx += 3 
     
         self.ego_embed = nn.Sequential(
             pufferlib.pytorch.layer_init(
-                nn.Linear(constants.EGO_FEAT_DIM, input_dim)
+                nn.Linear(self.ego_state_idx, input_dim)
             ),
             nn.LayerNorm(input_dim),
             self.act_func,


### PR DESCRIPTION
### Description

Add option for randomized rewards, based on "Robust Autonomy Emerges from Self-Play" Appendix B.3 

- Resample weights every episode (at reset)
- Sample weights from uniform distribution given some upper and lower bound
- Currently supported for 3 reward components, more can be added if required


### Todo

- [x] add reward randomization to env
- [x] add vector of rewards [3, 1] to agent ego state such that agents know their own type
- [x] extend network to new ego state dim if type is added