### PR TITLE
[REVERT] reverting usage of bev obs in get_obs

### DIFF
--- a/gpudrive/env/env_torch.py
+++ b/gpudrive/env/env_torch.py
@@ -1169,19 +1169,7 @@ class GPUDriveTorchEnv(GPUDriveGymEnv):
         ego_states = self._get_ego_state(mask)
         partner_observations = self._get_partner_obs(mask)
         road_map_observations = self._get_road_map_obs(mask)
-
-        # Rasterized observation, see https://github.com/Emerge-Lab/gpudrive/pull/390
-        if self.config.bev_obs:
-            bev_observations = self._get_bev_obs(mask)
-            obs = torch.cat(
-                (
-                    ego_states,
-                    bev_observations,
-                ),
-                dim=-1,
-            )
-
-        elif (
+        if (
             self.use_vbd
             and self.vbd_model is not None
             and self.config.vbd_in_obs


### PR DESCRIPTION
This change allows the usage of `bev_obs=True` in an environment config without forcing the user to only receive bev obs from the environment. 

This is useful because currently the bev obs are unusable for standard RL training, and thus typically useful in concert with other observation types.