### PR TITLE
Let agents know their true size 

### DIFF
--- a/gpudrive/datatypes/observation.py
+++ b/gpudrive/datatypes/observation.py
@@ -7,6 +7,8 @@ from gpudrive.utils.geometry import (
 )
 import madrona_gpudrive
 
+AGENT_SCALE = madrona_gpudrive.vehicleScale
+
 
 class LocalEgoState:
     """A class to represent the ego state of the agent in relative coordinates.
@@ -29,8 +31,8 @@ class LocalEgoState:
         if mask is not None:
             self_obs_tensor = self_obs_tensor[mask]
             self.speed = self_obs_tensor[:, 0]
-            self.vehicle_length = self_obs_tensor[:, 1]
-            self.vehicle_width = self_obs_tensor[:, 2]
+            self.vehicle_length = self_obs_tensor[:, 1] * AGENT_SCALE
+            self.vehicle_width = self_obs_tensor[:, 2] * AGENT_SCALE
             self.vehicle_height = self_obs_tensor[:, 3]
             self.rel_goal_x = self_obs_tensor[:, 4]
             self.rel_goal_y = self_obs_tensor[:, 5]
@@ -38,8 +40,8 @@ class LocalEgoState:
             self.id = self_obs_tensor[:, 7]
         else:
             self.speed = self_obs_tensor[:, :, 0]
-            self.vehicle_length = self_obs_tensor[:, :, 1]
-            self.vehicle_width = self_obs_tensor[:, :, 2]
+            self.vehicle_length = self_obs_tensor[:, :, 1] * AGENT_SCALE
+            self.vehicle_width = self_obs_tensor[:, :, 2] * AGENT_SCALE
             self.vehicle_height = self_obs_tensor[:, :, 3]
             self.rel_goal_x = self_obs_tensor[:, :, 4]
             self.rel_goal_y = self_obs_tensor[:, :, 5]
@@ -117,8 +119,8 @@ class GlobalEgoState:
         self.rotation_angle = abs_self_obs_tensor[:, :, 7]
         self.goal_x = abs_self_obs_tensor[:, :, 8]
         self.goal_y = abs_self_obs_tensor[:, :, 9]
-        self.vehicle_length = abs_self_obs_tensor[:, :, 10]
-        self.vehicle_width = abs_self_obs_tensor[:, :, 11]
+        self.vehicle_length = abs_self_obs_tensor[:, :, 10] * AGENT_SCALE
+        self.vehicle_width = abs_self_obs_tensor[:, :, 11] * AGENT_SCALE
         self.vehicle_height = abs_self_obs_tensor[:, :, 12]
         self.id = abs_self_obs_tensor[:, :, 13]
 
@@ -139,7 +141,7 @@ class GlobalEgoState:
     def shape(self) -> tuple[int, ...]:
         """Shape (num_worlds, num_agents) of the ego state tensor."""
         return self.pos_x.shape
-    
+
     def restore_mean(self, mean_x, mean_y):
         """Reapplies the mean to revert back to the original coordinates.
         - self.pos_x and self.pos_y are modified in place are of shape (num_worlds, num_agents).
@@ -148,9 +150,10 @@ class GlobalEgoState:
         # Reshape the mean to broadcast
         mean_x_reshaped = mean_x.view(-1, 1)
         mean_y_reshaped = mean_y.view(-1, 1)
-        
+
         self.pos_x += mean_x_reshaped
         self.pos_y += mean_y_reshaped
+
 
 @dataclass
 class PartnerObs:
@@ -176,13 +179,19 @@ class PartnerObs:
         self.mask = mask
         if self.mask is not None:  # Used for training
             self.data = partner_obs_tensor[self.mask][:, :, :6]
+            self.data[:, :, 4] *= AGENT_SCALE
+            self.data[:, :, 5] *= AGENT_SCALE
         else:
             self.speed = partner_obs_tensor[:, :, :, 0].unsqueeze(-1)
             self.rel_pos_x = partner_obs_tensor[:, :, :, 1].unsqueeze(-1)
             self.rel_pos_y = partner_obs_tensor[:, :, :, 2].unsqueeze(-1)
             self.orientation = partner_obs_tensor[:, :, :, 3].unsqueeze(-1)
-            self.vehicle_length = partner_obs_tensor[:, :, :, 4].unsqueeze(-1)
-            self.vehicle_width = partner_obs_tensor[:, :, :, 5].unsqueeze(-1)
+            self.vehicle_length = (
+                partner_obs_tensor[:, :, :, 4].unsqueeze(-1) * AGENT_SCALE
+            )
+            self.vehicle_width = (
+                partner_obs_tensor[:, :, :, 5].unsqueeze(-1) * AGENT_SCALE
+            )
             self.vehicle_height = partner_obs_tensor[:, :, :, 6].unsqueeze(-1)
             self.agent_type = (
                 partner_obs_tensor[:, :, :, 7].unsqueeze(-1).long()
@@ -336,11 +345,12 @@ class BevObs:
     def shape(self) -> tuple[int, ...]:
         """Shape: (num_worlds, num_agents, resolution, resolution, 1)."""
         return self.bev_segmentation_map.shape
-    
+
     def one_hot_encode_bev_map(self):
         """One-hot encodes the agent types. This operation increases the
         number of features by 10.
-        """     
+        """
         self.bev_segmentation_map = torch.nn.functional.one_hot(
-            self.bev_segmentation_map.long(), num_classes=constants.NUM_MADRONA_ENTITY_TYPES # From size of Madrona EntityType
+            self.bev_segmentation_map.long(),
+            num_classes=constants.NUM_MADRONA_ENTITY_TYPES,  # From size of Madrona EntityType
         )

--- a/gpudrive/env/config.py
+++ b/gpudrive/env/config.py
@@ -129,6 +129,9 @@ class EnvConfig:
         madrona_gpudrive.episodeLen
     )  # Length of an episode in the simulator
     num_lidar_samples: int = madrona_gpudrive.numLidarSamples
+    # Agent size scale factor (0.0-1.0)
+    # Controls the visual and collision size of vehicles in the simulation.
+    agent_size_scale: float = madrona_gpudrive.vehicleScale
 
     # Initialization mode
     init_mode: str = (

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -25,6 +25,7 @@ namespace madrona_gpudrive
         m.attr("kMaxAgentMapObservationsCount") = consts::kMaxAgentMapObservationsCount;
         m.attr("episodeLen") = consts::episodeLen;
         m.attr("numLidarSamples") = consts::numLidarSamples;
+        m.attr("vehicleScale") = consts::vehicleLengthScale;
 
         // Define RewardType enum
         nb::enum_<RewardType>(m, "RewardType")


### PR DESCRIPTION
### Description  

GPUDrive slightly rescales the length and width of agents to:  
1. Account for noise in the dataset that occasionally places agents in initial collisions.  
2. Ensure all vehicles fit on the road and can reach their goals.  

The scaling factor is currently set to 0.7 but could be increased to 0.9 while maintaining a benchmark ceiling of 100% (i.e., all scenes remain solvable). I plan to look into this in the future.  

For now, this PR correctly applies the scaling factor to vehicle dimensions, allowing agents to perceive their true size. This is important for evaluation on standard benchmarks such as WOSAC.