### PR TITLE
Add missing deps and CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.*
+!.git
+!.gitignore
+!.gitmodules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-smoketest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        run: docker build --tag gpudrive:latest .
+
+      - name: Run smoke test inside Docker container
+        run: |
+          docker run --rm gpudrive:latest /bin/bash -c "
+            echo 'Dummy cuda' \
+            && ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+            && export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH \
+            && echo 'Modifications to run without extra data' \
+            && sed -i 's|train_path: \"data/processed/training\"|train_path: \"data/processed/examples\"|g' examples/experimental/config/visualization_config.yaml \
+            && sed -i '/# Load policy/{N;N;N;N;N;N;s|# Load policy\n    policy = load_policy(\n        path_to_cpt=config.cpt_path,\n        model_name=config.cpt_name,\n        device=config.device,\n        env=env,\n    )|from gpudrive.networks.late_fusion import NeuralNet\n    policy = NeuralNet.from_pretrained(\"daphne-cornelisse/policy_S10_000_02_27\")|}' examples/experimental/viz_rollouts.py \
+            && echo 'Modifications to run without GPU' \
+            && sed -i 's/device=\"cuda\"/device=\"cpu\"/g' gpudrive/datatypes/observation.py \
+            && python examples/experimental/viz_rollouts.py
+          "

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install essential packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
 	software-properties-common \
         build-essential \
         cmake \
@@ -22,12 +22,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxi-dev \
         mesa-common-dev \
         libc++1 \
-        openssh-client && \
-    rm -rf /var/lib/apt/lists/*
+        openssh-client \
+        ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python 3.11
 RUN apt-add-repository -y ppa:deadsnakes/ppa \
-    && apt-get install -y python3.11 python3.11-dev python3.11-distutils
+    && apt-get install -y -q --no-install-recommends python3.11 python3.11-dev python3.11-distutils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 
@@ -35,22 +39,27 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 11 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.11 11
 
-RUN apt-get remove -y cmake && pip3 install --upgrade cmake
+RUN apt-get remove -y cmake && pip3 install  --no-cache-dir --upgrade cmake
 
-# Clone the gpudrive repository
-RUN git clone --recursive https://github.com/Emerge-Lab/gpudrive.git --branch dev-packaged
+# Copy the gpudrive repository
+COPY . /gpudrive
+WORKDIR /gpudrive
+RUN git submodule update --init --recursive --depth 1
+
 ENV MADRONA_MWGPU_KERNEL_CACHE=./gpudrive_cache
 
-WORKDIR /gpudrive
 RUN mkdir build
 WORKDIR /gpudrive/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 && find external -type f -name "*.tar" -delete
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 RUN LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH make -j
 RUN rm /usr/local/cuda/lib64/stubs/libcuda.so.1
 WORKDIR /gpudrive
 
-RUN pip3 install -e .[pufferlib]
+RUN pip3 install --no-cache-dir torch==2.6.0 && rm -rf ~/.cache/pip/*
+RUN pip3 install --no-cache-dir tensorflow==2.19.0 && rm -rf ~/.cache/pip/*
+RUN pip3 install --no-cache-dir nvidia-cuda-runtime-cu12==12.4.127 && rm -rf ~/.cache/pip/*
+RUN pip3 install --no-cache-dir -e .[vbd,pufferlib]
 
 CMD ["/bin/bash"]
 LABEL org.opencontainers.image.source=https://github.com/Emerge-Lab/gpudrive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "seaborn",
     "safetensors",
     "python-box",
+    "tqdm",
+    "jax",
+    "huggingface_hub",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds a basic CI to test the installation using the provided Dockerfile, to make sure it stays up to date. Some dependencies had to be added for this.

The pipeline can be seen here:
- https://github.com/m-naumann/gpudrive/actions/runs/14254130810/job/39953432183?pr=1

triggered from:
- https://github.com/m-naumann/gpudrive/pull/1

For the pipeline to be run in this repo, an admin has to trigger it manually, I think.

Some details:
- In order to test the functionality (on CPU only, due to lack of GPU runners), some modifications are made to existing files using `sed` in the last step of the pipeline. In the future, these modifications could be done using command-line args to the script `examples/experimental/viz_rollouts.py`, to get rid of `sed`.
- Instead of cloning the repo during build, I copied it, such that it always contains the current status of the repo (both in CI for PRs and also when testing locally)
- For CI, I had to pre-install some large pip packages and clear the cache afterwards, otherwise it would run out of diskspace