### PR TITLE
Add advantage filtering support for PPO

### DIFF
--- a/baselines/ppo/config/ppo_base_puffer.yaml
+++ b/baselines/ppo/config/ppo_base_puffer.yaml
@@ -78,6 +78,10 @@ train:
   max_grad_norm: 0.5
   target_kl: null
   log_window: 1000
+  # Advantage filtering
+  apply_advantage_filter: true
+  initial_th_factor: 0.01
+  beta: 0.25
 
   # # # Network # # #
   network:

--- a/baselines/ppo/ppo_pufferlib.py
+++ b/baselines/ppo/ppo_pufferlib.py
@@ -189,6 +189,10 @@ def run(
     minibatch_size: Annotated[Optional[int], typer.Option(help="The minibatch size for training")] = None,
     gamma: Annotated[Optional[float], typer.Option(help="The discount factor for rewards")] = None,
     vf_coef: Annotated[Optional[float], typer.Option(help="Weight for vf_loss")] = None,
+    # Advantage filtering
+    apply_advantage_filter: Annotated[Optional[int], typer.Option(help="Whether to use advantage filter; 0 or 1")] = None,
+    initial_th_factor: Annotated[Optional[float], typer.Option(help="Initial threshold factor for training")] = None,
+    beta: Annotated[Optional[float], typer.Option(help="Beta parameter for training")] = None,
     # Wandb logging options
     project: Annotated[Optional[str], typer.Option(help="WandB project name")] = None,
     entity: Annotated[Optional[str], typer.Option(help="WandB entity name")] = None,
@@ -242,6 +246,9 @@ def run(
         "render": None if render is None else bool(render),
         "gamma": gamma,
         "vf_coef": vf_coef,
+        "apply_advantage_filter": apply_advantage_filter,
+        "initial_th_factor": initial_th_factor,
+        "beta": beta,
     }
     config.train.update(
         {k: v for k, v in train_config.items() if v is not None}


### PR DESCRIPTION
## Description

Implements advantage filtering from "Robust Autonomy Emerges from Self-Play" (Details in Appendix C, Algorithm 1).

The key idea is to discard transitions with low-magnitude advantages to focus training on the most informative samples.

Added config options: 
- `apply_advantage_filter`
- `beta` (0.25)
- `initial_th_factor` (0.01)

## Todo
- [x] Implement Advantage Filtering with existing `Experience` buffer, preserving the shape of tensors. Zero-out all transitions < threshold.
- [ ] Restructure `Experience` buffer to actually filter out such transitions, for memory and training efficiency