### PR TITLE
Fix out of range error for VBD trajectory

### DIFF
--- a/src/json_serialization.hpp
+++ b/src/json_serialization.hpp
@@ -194,13 +194,14 @@ namespace madrona_gpudrive
             int vbd_idx = 0;
             for (const auto &vbd_traj : j.at("vbd_trajectory")) {
                 if (vbd_idx < consts::kTrajectoryLength) {
-                    if (!vbd_traj.is_null() && vbd_traj.is_array() && vbd_traj.size() >= 6) {
-                        obj.vbd_trajectories[vbd_idx][0] = vbd_traj.at(0).get<float>();
-                        obj.vbd_trajectories[vbd_idx][1] = vbd_traj.at(1).get<float>();
-                        obj.vbd_trajectories[vbd_idx][2] = vbd_traj.at(2).get<float>();
-                        obj.vbd_trajectories[vbd_idx][3] = vbd_traj.at(3).get<float>();
-                        obj.vbd_trajectories[vbd_idx][4] = vbd_traj.at(4).get<float>();
-                        obj.vbd_trajectories[vbd_idx][5] = vbd_traj.at(5).get<float>();
+                    if (!vbd_traj.is_null() && vbd_traj.is_array()) {
+                        size_t traj_size = vbd_traj.size();
+                        if (traj_size > 0) obj.vbd_trajectories[vbd_idx][0] = vbd_traj.at(0).get<float>();
+                        if (traj_size > 1) obj.vbd_trajectories[vbd_idx][1] = vbd_traj.at(1).get<float>();
+                        if (traj_size > 2) obj.vbd_trajectories[vbd_idx][2] = vbd_traj.at(2).get<float>();
+                        if (traj_size > 3) obj.vbd_trajectories[vbd_idx][3] = vbd_traj.at(3).get<float>();
+                        if (traj_size > 4) obj.vbd_trajectories[vbd_idx][4] = vbd_traj.at(4).get<float>();
+                        if (traj_size > 5) obj.vbd_trajectories[vbd_idx][5] = vbd_traj.at(5).get<float>();
                     }
                 }
                 vbd_idx++;


### PR DESCRIPTION
I got a `out_of_range was thrown in -fno-exceptions mode with message "vector"` error when creating the torch env in tutorial 6. The gdb backtrace led to [this line](https://github.com/Emerge-Lab/gpudrive/blob/56529c2ed85cf3949399035550f896f46fc86824/src/json_serialization.hpp#L165) in the json serialization for the vbd trajectory. 

I'm not familiar with the vbd data part, but it seems that some trajectories have less than 6 elements (while the previous code assumed exactly 6 always). Adding safe index checking and other sanity checks regarding types solved the error :)