### PR TITLE
[FEATURE] allow unrolling expert trajectories in `get_model_performance`

### DIFF
--- a/examples/experimental/config/expert_replay_config.yaml
+++ b/examples/experimental/config/expert_replay_config.yaml
@@ -1,12 +1,12 @@
 res_path: examples/experimental/dataframes # Store dataframes here
-test_dataset_size: 10_000 # Number of test scenarios to evaluate on
+test_dataset_size: 300 # Number of test scenarios to evaluate on
 
 # Environment settings
 train_dir: data/processed/training 
-test_dir: data/processed/validation
-file_prefix: null
+test_dir: data/processed/validation 
+file_prefix: nuplan
 
-num_worlds: 50 # Number of parallel environments for evaluation
+num_worlds: 100 # Number of parallel environments for evaluation
 max_controlled_agents: 64 # Maximum number of agents controlled by the model.
 ego_state: true
 road_map_obs: true
@@ -18,7 +18,7 @@ reward_type: "weighted_combination"
 collision_weight: -0.75
 off_road_weight: -0.75
 goal_achieved_weight: 1.0
-dynamics_model: "classic"
+dynamics_model: "delta_local"
 collision_behavior: "ignore" # Options: "remove", "stop"
 dist_to_goal_threshold: 2.0
 polyline_reduction_threshold: 0.1 # Rate at which to sample points from the polyline (0 is use all closest points, 1 maximum sparsity), needs to be balanced with kMaxAgentMapObservationsCount
@@ -27,7 +27,7 @@ obs_radius: 50.0 # Visibility radius of the agents
 init_roadgraph: False
 render_3d: True
 
-action_type: "discrete"
+action_type: "continuous"
 # Number of discretizations in the action space
 # Note: Make sure that this equals the discretizations that the policy
 # has been trained with

--- a/examples/experimental/config/model_config.yaml
+++ b/examples/experimental/config/model_config.yaml
@@ -1,7 +1,7 @@
 models_path: examples/experimental/models
 
 models:
-  - name: model_PPO____R_10000__02_27_09_19_10_626_003200
-    train_dataset_size: 10_000
+  - name: expert_replay
+    train_dataset_size: 1000
     wandb: null
     trained_on: null

--- a/examples/experimental/get_model_performance.py
+++ b/examples/experimental/get_model_performance.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
             else 1000,
             sample_with_replacement=False,
             shuffle=False,
+            file_prefix=eval_config.file_predix
         )
 
         test_loader = SceneDataLoader(
@@ -74,6 +75,7 @@ if __name__ == "__main__":
             else 1000,
             sample_with_replacement=False,
             shuffle=True,
+            file_prefix=eval_config.file_predix
         )
 
         # Rollouts

--- a/gpudrive/visualize/core.py
+++ b/gpudrive/visualize/core.py
@@ -10,7 +10,6 @@ from matplotlib.collections import LineCollection
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection, Line3DCollection
 from matplotlib.colors import ListedColormap
-from jaxlib.xla_extension import ArrayImpl
 import numpy as np
 import madrona_gpudrive
 from gpudrive.visualize import utils
@@ -78,10 +77,12 @@ class MatplotlibVisualizer:
         )
         self.controlled_agent_mask = controlled_agent_mask
 
-        if isinstance(controlled_agent_mask, ArrayImpl):
-            self.controlled_agent_mask = torch.from_numpy(
-                np.array(controlled_agent_mask)
-            )
+        if self.backend == "jax":
+            from jaxlib.xla_extension import ArrayImpl
+            if isinstance(controlled_agent_mask, ArrayImpl):
+                self.controlled_agent_mask = torch.from_numpy(
+                    np.array(controlled_agent_mask)
+                )
 
         self.controlled_agent_mask = self.controlled_agent_mask.to(self.device)
 


### PR DESCRIPTION
Adding this as a sanity check, mainly for the `nuplan` data.

My assumption is that when replaying the log trajectories we would see 100% goal completion, and very low off-road and collision rates. This would indicate that "perfect" driving on these scenarios is possible (I had a slight fear that the nuplan agents had a higher off-road rate due to an issue with the data). 

When I evaluate 1300 nuplan scenarios with the expert trajectories we see:

```
        goal_achieved_frac      collided_frac      off_road_frac      other_frac     
                      mean  std          mean  std          mean  std       mean  std
dataset                                                                              
test                 100.0  0.0           0.0  0.6           1.2  6.1        0.0  0.0
train                100.0  0.0           0.0  0.5           1.4  8.6        0.0  0.0

Agent-based metrics 

Total agents: 20918.0 in 1300 scenes
Collision rate: 0.028683431446552277
Offroad rate: 0.5975714884698391
Goal rate: 100.0
Other rate: 0.0
```

The off-road rate is still a bit higher than I might expect, but it is still significantly lower than the best we have recorded on nuplan scenarios so far (~8%).