### PR TITLE
[FIX] consistent seed in DL for ppo_pufferlib

### DIFF
--- a/baselines/ppo/ppo_pufferlib.py
+++ b/baselines/ppo/ppo_pufferlib.py
@@ -291,6 +291,7 @@ def run(
         else config.environment.k_unique_scenes,
         sample_with_replacement=config.train.sample_with_replacement,
         shuffle=config.train.shuffle_dataset,
+        seed=seed,
     )
 
     # Make environment


### PR DESCRIPTION
Currently it is possible to unknowngly use two different seeds for the PPO and dataloader. Normally if everyone was using 42 for the seed there would be no effect, but we tested with varying seeds and had unintuitive results, so I think matching the seeds here makes sense.