### PR TITLE
Repaired a bug causing wrong agent ids in abs_self_obs

### DIFF
--- a/src/level_gen.cpp
+++ b/src/level_gen.cpp
@@ -318,6 +318,13 @@ void createPaddingEntities(Engine &ctx) {
         }
         auto &self_obs = ctx.get<SelfObservation>(agent_iface);
         self_obs = SelfObservation::zero();
+	
+        auto &abs_self_obs = ctx.get<AbsoluteSelfObservation>(agent_iface);
+        abs_self_obs.position = Vector3::zero();
+        abs_self_obs.rotation = AbsoluteRotation{.rotationAsQuat = Quat{1, 0, 0, 0}, .rotationFromAxis = 0};
+        abs_self_obs.goal = Goal{.position = {0, 0}};
+        abs_self_obs.vehicle_size = VehicleSize{.length = 0, .width = 0, .height = 0};
+        abs_self_obs.id = -1.0f;
 
         auto &partner_obs = ctx.get<PartnerObservations>(agent_iface);
         for (CountT i = 0; i < consts::kMaxAgentCount-1; i++) {


### PR DESCRIPTION
# Problem
This bug is about the id of padding agents in absolute_self_observation_tensor, making the id of padding agents 0 rather than -1.
<img width="1478" height="456" alt="image" src="https://github.com/user-attachments/assets/7e9be595-72f5-4046-9f93-716998a5ff83" />
# Reason
abs_self_obs is initialized automatically, so the values of all the attributes are set as zero by default.
# Solution
Manually initialize it in createPaddingEntities.